### PR TITLE
[#84]  : 다크모드일때 색상 지정 tailwindconfig 수정

### DIFF
--- a/src/Components/common/Header.jsx
+++ b/src/Components/common/Header.jsx
@@ -4,7 +4,7 @@ import NavTitle from "./NavTitle";
 
 export default function Header() {
   return (
-    <div className="fixed z-50 flex h-16 w-full items-center justify-between bg-dark-bg px-4 shadow-md">
+    <div className="fixed z-50 flex h-16 w-full items-center justify-between border-red-500 bg-dark-card-bg px-4 shadow-md dark:border-b dark:bg-dark-bg">
       <DarkmodeSwitch className="md:-order-first" />
       <div className="flex items-center gap-5">
         <NavTitle />

--- a/src/Components/common/menubar/ManagerMenuBar.tsx
+++ b/src/Components/common/menubar/ManagerMenuBar.tsx
@@ -1,42 +1,40 @@
 import { Button } from "@/components/ui/button";
-import { Switch } from "@/components/ui/switch";
 import {
   Sidebar,
   SidebarContent,
   SidebarHeader,
   SidebarFooter,
-  SidebarProvider,
   useSidebar,
 } from "@/components/ui/sidebar";
-import { Moon, Sun, LogOut } from "lucide-react";
-import { cn } from "@/util/cn.util";
+import { LogOut } from "lucide-react";
+
 import { useMenuBar } from "@/hooks/menu/useMenuBar";
 import ManagerMenuBarList from "./manager/ManagerMenuBarList";
 import AppTitle from "../AppTitle";
 
 export const ManagerMenuBar = () => {
-  const { companyLogo, companyName, darkMode, toggleTheme, logout } = useMenuBar();
+  const { logout } = useMenuBar();
   const { isMobile } = useSidebar();
 
   return (
     <Sidebar
       side={isMobile ? "right" : "left"}
-      className="h-screen w-64 border-r border-gray-200 bg-gray-100 dark:border-gray-800 dark:bg-[#1E1E1E]"
+      className="h-screen w-64 border-r border-gray-200 bg-white-bg dark:border-gray-100 dark:bg-dark-bg"
     >
-      <SidebarHeader className="flex h-16 items-center justify-center gap-2 bg-dark-bg p-4 font-bold">
+      <SidebarHeader className="flex h-16 items-center justify-center gap-2 border-solid border-dark-border bg-dark-card-bg p-4 font-bold dark:bg-dark-bg">
         <AppTitle className="text-white" />
       </SidebarHeader>
 
-      <SidebarContent className="overflow-y-auto">
+      <SidebarContent className="overflow-y-auto dark:bg-dark-bg">
         <ManagerMenuBarList />
       </SidebarContent>
 
-      <SidebarFooter className="mt-auto border-t border-gray-200 p-4 dark:border-gray-800">
+      <SidebarFooter className="mt-auto border-t border-gray-200 p-4 dark:border-gray-800 dark:bg-dark-bg">
         <Button
           variant="default"
           size="sm"
           onClick={logout}
-          className="flex w-full items-center justify-center gap-2 border-gray-300 text-gray-700 dark:border-gray-700 dark:text-gray-300"
+          className="flex w-full items-center justify-center gap-2 border-gray-300 text-gray-700 dark:border dark:border-solid dark:border-dark-border-sub dark:bg-dark-bg dark:text-dark-text hover:dark:bg-dark-card-bg"
         >
           <LogOut className="h-4 w-4" />
           <span>로그아웃</span>

--- a/src/Components/company/ManagerMainContent.tsx
+++ b/src/Components/company/ManagerMainContent.tsx
@@ -1,9 +1,9 @@
 import { useNavigate } from "react-router-dom";
 import { useUserStore } from "@/store/user.store";
 import { useShallow } from "zustand/shallow";
+import { Card } from "../ui/card";
 
 const ManagerMainContent = () => {
-  const navigate = useNavigate();
   const { companyCode } = useUserStore(
     useShallow(state => ({
       companyCode: state.currentUser?.companyCode,

--- a/src/Components/ui/card.tsx
+++ b/src/Components/ui/card.tsx
@@ -6,7 +6,10 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn("rounded-lg border bg-card text-card-foreground", className)}
+      className={cn(
+        "rounded-lg border bg-white text-card-foreground dark:bg-dark-card-bg",
+        className,
+      )}
       {...props}
     />
   ),

--- a/src/Components/ui/sidebar.tsx
+++ b/src/Components/ui/sidebar.tsx
@@ -258,7 +258,7 @@ const SidebarTrigger = React.forwardRef<
       data-sidebar="trigger"
       size="icon"
       className={cn(
-        "z-50 h-10 w-10 rounded-lg bg-dark-bg p-2 transition-all duration-200",
+        "z-50 h-10 w-10 rounded-lg bg-dark-card-bg p-2 transition-all duration-200 dark:bg-dark-bg",
         "hover:bg-gray-700",
         "focus:ring-2 focus:ring-dark-border",
         "active:scale-95",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,8 +7,9 @@ export default {
   theme: {
     extend: {
       colors: {
-        "dark-bg": "#202020",
-        "dark-card-bg": "#2A2A2A",
+        "point-color": "#FFD369",
+        "dark-bg": "#09090B",
+        "dark-card-bg": "#202020",
         "dark-text": "#FFFFFF",
         "dark-border": "#FFFFFF80",
         "dark-border-sub": "#FFFFFF33",


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 다크모드일때 색상 지정 tailwindconfig 수정

```ts
"point-color": "#FFD369",
"dark-bg": "#09090B",
"dark-card-bg": "#202020",
```

- bg 가 더 진한 색깔, card는 비교적 탁한 색깔로 변경하였습니다.
- point 색상은 필요할때 포인트 주는 용도로만 사용하기 

> point 색상
![Screenshot 2025-03-01 at 9 40 54 PM](https://github.com/user-attachments/assets/9d90f9de-7fe0-4c03-8d52-879a2f87dea2)


> 다크모드일때 예시
![Screenshot 2025-03-01 at 9 41 30 PM](https://github.com/user-attachments/assets/a5e897f1-e38a-494e-8c27-b12def3e0709)

> 카드 색상 지정시 주의할점
반드시 dark:dark-card-bg 로 카드 색션 만들어주세요 기본으로 지정 안되어 있어서 직접 지정 필요



### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
