### PR TITLE
[#123] : 휴가 요청/등록 타입 지정 (+데이터 구조)

### DIFF
--- a/src/model/types/vacation.type.ts
+++ b/src/model/types/vacation.type.ts
@@ -1,0 +1,31 @@
+import { TJobList, TSelectableJobName } from "./company.type";
+import { TUserBase } from "./user.type";
+
+export type TVacationType = "반차" | "연차" | "특별";
+export type TVacationStatus = "대기중" | "승인됨" | "거절됨" | "자동 승인됨";
+
+// 휴가 요청 타입
+export type TVacationRequest<T extends TJobList = TJobList> = {
+  requestId: string;
+  requester: Pick<TUserBase, "uid" | "name" | "email"> & { jobName: TSelectableJobName<T> };
+  vacationType: TVacationType;
+  startDate: string; // "YYYY-MM-DD"
+  endDate: string; // "YYYY-MM-DD"
+  reason: string;
+  status: Exclude<TVacationStatus, "자동 승인됨">; // "대기중" | "승인됨" | "거절됨"
+  createdAt: string; // ISO 문자열 (저장은 문자열로, 필요시 date로 객체 변환)
+  processedAt?: string; // 처리된 시간 (승인/거절 시점)
+};
+
+// 등록된 휴가 타입
+export type TRegisteredVacation<T extends TJobList = TJobList> = {
+  registerId: string;
+  startDate: string;
+  endDate: string;
+  vacationType: TVacationType;
+  status: "자동 승인됨";
+  reason: string;
+  createdAt: string;
+} & Pick<TUserBase, "name" | "email"> & {
+    jobName: TSelectableJobName<T>;
+  };


### PR DESCRIPTION
## #️⃣연관된 이슈

> #123 

## 📝작업 내용

> 데이터 구조
![스크린샷 2025-03-24 오후 4 34 02](https://github.com/user-attachments/assets/0be023f8-17ac-40fc-a838-07b3efb20006)

> 휴가 요청 데이터
```tsx
export type TVacationRequest<T extends TJobList = TJobList> = {
  requestId: string;
  requester: Pick<TUserBase, "uid" | "name" | "email"> & { jobName: TSelectableJobName<T> };
  vacationType: TVacationType;
  startDate: string; // "YYYY-MM-DD"
  endDate: string; // "YYYY-MM-DD"
  reason: string;
  status: Exclude<TVacationStatus, "자동 승인됨">; // "대기중" | "승인됨" | "거절됨"
  createdAt: string; // ISO 문자열
  processedAt?: string; // 처리된 시간 (승인/거절 시점)
};
```

- requester는 user타입에 있는 데이터를 가져왔습니다.
- createdAt 문자열 타입 지정 이유 : date로 타입을 지정하면 애초에 firebase에서 Date 객체를 지원하지 않고 따로 문자열로 변환해서 저장해야함.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
