### PR TITLE
[#129] : month picker 차트에 적용 및 직원 검색시 자동완성 기능

### DIFF
--- a/src/Components/common/AutoCompleteInput.tsx
+++ b/src/Components/common/AutoCompleteInput.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { UserIcon, MailIcon, BriefcaseIcon } from "lucide-react";
+import { TEmpUserData } from "@/model/types/user.type";
+
+interface IAutoCompleteUserInputProps {
+  users: TEmpUserData[];
+  onSelect: (user: TEmpUserData) => void;
+}
+
+const AutoCompleteUserInput = ({ users, onSelect }: IAutoCompleteUserInputProps) => {
+  const [inputValue, setInputValue] = useState("");
+  const [filteredUsers, setFilteredUsers] = useState<TEmpUserData[]>([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setInputValue(value);
+
+    if (value.length === 0) {
+      setShowSuggestions(false);
+      setFilteredUsers([]);
+      return;
+    }
+
+    const filtered = users.filter(user => user.name.toLowerCase().includes(value.toLowerCase()));
+
+    setFilteredUsers(filtered);
+    setShowSuggestions(true);
+  };
+
+  const handleSelect = (user: TEmpUserData) => {
+    setInputValue(user.name);
+    setShowSuggestions(false);
+    onSelect(user);
+  };
+
+  return (
+    <div className="relative w-full">
+      <Input
+        value={inputValue}
+        onChange={handleChange}
+        placeholder="이름 검색"
+        className="h-full w-full rounded-md placeholder:text-sm"
+      />
+      {showSuggestions && filteredUsers.length > 0 && (
+        <ul className="absolute z-10 mt-2 max-h-72 w-full overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg">
+          {filteredUsers.map((user, idx) => (
+            <li
+              key={idx}
+              onClick={() => handleSelect(user)}
+              className="cursor-pointer px-4 py-3 transition-colors duration-150 hover:bg-gray-100"
+            >
+              <div className="flex items-start gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-200 text-gray-600">
+                  <UserIcon size={18} />
+                </div>
+                <div className="flex flex-col">
+                  <span className="text-sm font-semibold text-gray-800">{user.name}</span>
+                  <div className="mt-1 flex items-center gap-1 text-xs text-gray-500">
+                    <MailIcon size={13} className="mr-1" />
+                    {user.email}
+                  </div>
+                  <div className="flex items-center gap-1 text-xs text-gray-500">
+                    <BriefcaseIcon size={13} className="mr-1" />
+                    {user.jobName} · {user.employmentType}
+                  </div>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default AutoCompleteUserInput;

--- a/src/Components/company/vacation/VacationChart.tsx
+++ b/src/Components/company/vacation/VacationChart.tsx
@@ -3,21 +3,19 @@ import { Card } from "@/components/ui/card";
 import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis, Tooltip, Legend } from "recharts";
 import { format, startOfMonth, endOfMonth, addDays } from "date-fns";
 
-// 📌 이번 달의 모든 날짜를 생성하는 함수
-const getMonthDates = () => {
-  const today = new Date();
-  const firstDay = startOfMonth(today);
-  const lastDay = endOfMonth(today);
+const getMonthDates = (year: number, month: number) => {
+  const firstDay = startOfMonth(new Date(year, month));
+  const lastDay = endOfMonth(new Date(year, month));
 
   let dates = [];
   for (let day = firstDay; day <= lastDay; day = addDays(day, 1)) {
-    dates.push(format(day, "MM-dd")); // "03-01", "03-02" 형식
+    dates.push(format(day, "MM-dd"));
   }
   return dates;
 };
 
-const generateDummyVacationData = () => {
-  const dates = getMonthDates();
+const generateDummyVacationData = (year: number, month: number) => {
+  const dates = getMonthDates(year, month);
   return dates.map(date => ({
     date,
     annual: Math.floor(Math.random() * 10),
@@ -26,14 +24,21 @@ const generateDummyVacationData = () => {
   }));
 };
 
-const VacationChart = () => {
-  const dummyVacationData = useMemo(() => generateDummyVacationData(), []);
+interface IVacationChartProps {
+  selectedMonth: { year: number; month: number };
+}
+
+const VacationChart = ({ selectedMonth }: IVacationChartProps) => {
+  const dummyVacationData = useMemo(() => {
+    return generateDummyVacationData(selectedMonth.year, selectedMonth.month);
+  }, [selectedMonth]);
+
   return (
     <Card className="p-4">
       <h2 className="mb-4 text-lg font-semibold">직원 휴가 사용 현황</h2>
       <ResponsiveContainer width="100%" height={300}>
         <BarChart data={dummyVacationData} className="text-sm" margin={{ left: 0, right: 10 }}>
-          <XAxis dataKey="date" stroke="gray" />
+          <XAxis stroke="gray" dataKey="date" />
           <YAxis stroke="gray" width={30} />
           <Tooltip />
           <Legend align="right" />

--- a/src/Components/company/vacation/VacationChart.tsx
+++ b/src/Components/company/vacation/VacationChart.tsx
@@ -1,7 +1,9 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis, Tooltip, Legend } from "recharts";
 import { format, startOfMonth, endOfMonth, addDays } from "date-fns";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { TEmpUserData } from "@/model/types/user.type";
 
 const getMonthDates = (year: number, month: number) => {
   const firstDay = startOfMonth(new Date(year, month));
@@ -25,29 +27,80 @@ const generateDummyVacationData = (year: number, month: number) => {
 };
 
 interface IVacationChartProps {
-  selectedMonth: { year: number; month: number };
+  selectedDate: { year: number; month: number };
+  selectedName: TEmpUserData | null;
 }
 
-const VacationChart = ({ selectedMonth }: IVacationChartProps) => {
+const VacationChart = ({ selectedDate, selectedName }: IVacationChartProps) => {
   const dummyVacationData = useMemo(() => {
-    return generateDummyVacationData(selectedMonth.year, selectedMonth.month);
-  }, [selectedMonth]);
+    return generateDummyVacationData(selectedDate.year, selectedDate.month);
+  }, [selectedDate]);
+
+  const [selectedData, setSelectedData] = useState<{
+    date: string;
+    annual: number;
+    half: number;
+    special: number;
+  } | null>(null);
+
+  const handleBarClick = (data: any) => {
+    setSelectedData(data); // data = { date, annual, half, special }
+  };
+
+  const handleClose = () => setSelectedData(null);
 
   return (
-    <Card className="p-4">
-      <h2 className="mb-4 text-lg font-semibold">직원 휴가 사용 현황</h2>
-      <ResponsiveContainer width="100%" height={300}>
-        <BarChart data={dummyVacationData} className="text-sm" margin={{ left: 0, right: 10 }}>
-          <XAxis stroke="gray" dataKey="date" />
-          <YAxis stroke="gray" width={30} />
-          <Tooltip />
-          <Legend align="right" />
-          <Bar dataKey="annual" fill="#0F4C75" name="연차" radius={[4, 4, 0, 0]} />
-          <Bar dataKey="half" fill="#3282B8" name="반차" radius={[4, 4, 0, 0]} />
-          <Bar dataKey="special" fill="#BBE1FA" name="특별 휴가" radius={[4, 4, 0, 0]} />
-        </BarChart>
-      </ResponsiveContainer>
-    </Card>
+    <>
+      <Card className="p-4">
+        <h2 className="mb-12 text-lg font-semibold">
+          {selectedDate && `${selectedDate.year}년 ${selectedDate.month + 1}월 `}
+          {selectedName ? `${selectedName.name}님의` : "전체"} 휴가 사용 현황
+        </h2>
+        <ResponsiveContainer width="100%" height={300}>
+          <BarChart data={dummyVacationData} className="text-sm" margin={{ left: 0, right: 10 }}>
+            <XAxis stroke="gray" dataKey="date" />
+            <YAxis stroke="gray" width={30} />
+            <Tooltip />
+            <Legend align="right" />
+            <Bar
+              dataKey="annual"
+              fill="#0F4C75"
+              name="연차"
+              radius={[4, 4, 0, 0]}
+              onClick={handleBarClick}
+            />
+            <Bar
+              dataKey="half"
+              fill="#3282B8"
+              name="반차"
+              radius={[4, 4, 0, 0]}
+              onClick={handleBarClick}
+            />
+            <Bar
+              dataKey="special"
+              fill="#BBE1FA"
+              name="특별 휴가"
+              radius={[4, 4, 0, 0]}
+              onClick={handleBarClick}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </Card>
+
+      {/* Fix : 여기 부분은 이제 해당 날짜에 휴가 사용중인, 사용한 인원 리스트 보여주는 모달로 교체 */}
+      <Dialog open={!!selectedData} onOpenChange={handleClose}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{selectedData?.date} 휴가 상세 정보</DialogTitle>
+          </DialogHeader>
+          <div className="mt-2 space-y-2 text-sm text-gray-700">
+            <p>연차: {selectedData?.annual}건</p>
+            <p>반차: {selectedData?.half}건</p>
+            <p>특별 휴가: {selectedData?.special}건</p>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 };
 

--- a/src/Components/company/vacation/VacationFilter.tsx
+++ b/src/Components/company/vacation/VacationFilter.tsx
@@ -1,18 +1,98 @@
 import { SlidersHorizontalIcon } from "lucide-react";
 import MonthPicker from "@/components/common/calendar/MonthPicker";
-import { Input } from "@/components/ui/input";
+
+import AutoCompleteUserInput from "@/components/common/AutoCompleteInput";
+import { TEmpUserData } from "@/model/types/user.type";
 
 interface IVacationFilterProps {
   selectedMonth: { year: number; month: number };
   setSelectedMonth: (value: { year: number; month: number }) => void;
+  handleNameSelect: (user: TEmpUserData) => void;
 }
 
-const VacationFilter = ({ selectedMonth, setSelectedMonth }: IVacationFilterProps) => {
+const VacationFilter = ({
+  selectedMonth,
+  setSelectedMonth,
+  handleNameSelect,
+}: IVacationFilterProps) => {
+  const dummyEmployees: TEmpUserData[] = [
+    {
+      uid: "1",
+      name: "김수현",
+      email: "soo@company.com",
+      phoneNumber: "010-1234-5678",
+      companyCode: "A123",
+      userType: "employee",
+      jobName: "프론트엔드",
+      employmentType: "정규직",
+    },
+    {
+      uid: "2",
+      name: "김수영",
+      email: "sooyoung@company.com",
+      phoneNumber: "010-2345-6789",
+      companyCode: "A123",
+      userType: "employee",
+      jobName: "백엔드",
+      employmentType: "계약직",
+    },
+    {
+      uid: "3",
+      name: "김수정",
+      email: "sujung@company.com",
+      phoneNumber: "010-3456-7890",
+      companyCode: "A123",
+      userType: "employee",
+      jobName: "디자이너",
+      employmentType: "정규직",
+    },
+    {
+      uid: "4",
+      name: "김수연",
+      email: "suyeon@company.com",
+      phoneNumber: "010-4567-8901",
+      companyCode: "A123",
+      userType: "employee",
+      jobName: "기획자",
+      employmentType: "정규직",
+    },
+    {
+      uid: "5",
+      name: "김수환",
+      email: "soohwan@company.com",
+      phoneNumber: "010-5678-9012",
+      companyCode: "A123",
+      userType: "employee",
+      jobName: "프론트엔드",
+      employmentType: "정규직",
+    },
+    {
+      uid: "6",
+      name: "김수빈",
+      email: "soobin@company.com",
+      phoneNumber: "010-6789-0123",
+      companyCode: "A123",
+      userType: "employee",
+      jobName: "백엔드",
+      employmentType: "정규직",
+    },
+    {
+      uid: "7",
+      name: "김수경",
+      email: "sookyung@company.com",
+      phoneNumber: "010-7890-1234",
+      companyCode: "A123",
+      userType: "employee",
+      jobName: "데이터 분석",
+      employmentType: "계약직",
+    },
+  ];
+
   return (
     <div className="flex w-full flex-col items-center gap-3 py-3 sm:flex-row md:w-fit">
       <SlidersHorizontalIcon className="hidden w-10 text-white-nav-text sm:block" />
       <MonthPicker value={selectedMonth} onChange={setSelectedMonth} />
-      <Input className="h-full w-full rounded-md placeholder:text-sm" placeholder="이름 검색" />
+      <AutoCompleteUserInput users={dummyEmployees} onSelect={handleNameSelect} />
     </div>
   );
 };

--- a/src/Components/company/vacation/VacationFilter.tsx
+++ b/src/Components/company/vacation/VacationFilter.tsx
@@ -1,17 +1,13 @@
-import { useCompanyStore } from "@/store/company.store";
 import { SlidersHorizontalIcon } from "lucide-react";
-import React, { useState } from "react";
 import MonthPicker from "@/components/common/calendar/MonthPicker";
 import { Input } from "@/components/ui/input";
 
-const VacationFilter = () => {
-  const today = new Date();
+interface IVacationFilterProps {
+  selectedMonth: { year: number; month: number };
+  setSelectedMonth: (value: { year: number; month: number }) => void;
+}
 
-  const [selectedMonth, setSelectedMonth] = useState({
-    year: today.getFullYear(),
-    month: today.getMonth(),
-  });
-
+const VacationFilter = ({ selectedMonth, setSelectedMonth }: IVacationFilterProps) => {
   return (
     <div className="flex w-full flex-col items-center gap-3 py-3 sm:flex-row md:w-fit">
       <SlidersHorizontalIcon className="hidden w-10 text-white-nav-text sm:block" />

--- a/src/Components/company/vacation/VacationPieChart.tsx
+++ b/src/Components/company/vacation/VacationPieChart.tsx
@@ -1,9 +1,9 @@
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
 
 const data = [
-  { name: "연차", value: 60, color: "#0F4C75", days: 12 }, // 파란색
-  { name: "반차", value: 25, color: "#3282B8", days: 5 }, // 초록색
-  { name: "특별 휴가", value: 15, color: "#BBE1FA", days: 3 }, // 노란색
+  { name: "연차", value: 60, color: "#0F4C75", days: 12 },
+  { name: "반차", value: 25, color: "#3282B8", days: 5 },
+  { name: "특별 휴가", value: 15, color: "#BBE1FA", days: 3 },
 ];
 
 const RADIAN = Math.PI / 180;

--- a/src/Components/company/vacation/VacationPieChart.tsx
+++ b/src/Components/company/vacation/VacationPieChart.tsx
@@ -1,3 +1,4 @@
+import { TEmpUserData } from "@/model/types/user.type";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
 
 const data = [
@@ -38,12 +39,17 @@ const CustomTooltip = ({ active, payload }: any) => {
   }
   return null;
 };
+interface IVacationPieChartProps {
+  selectedDate: { year: number; month: number };
+  selectedName: TEmpUserData | null;
+}
 
-const VacationPieChart = () => {
+const VacationPieChart = ({ selectedDate, selectedName }: IVacationPieChartProps) => {
   return (
     <div className="flex flex-col items-center">
       <h3 className="mb-3 text-lg font-semibold text-white-text dark:text-dark-text">
-        기간내 휴가 유형별 비율
+        {selectedDate && `${selectedDate.year}년 ${selectedDate.month + 1}월 `}
+        {selectedName ? `${selectedName.name}님의` : "전체"} 유형별 휴가 사용 현황
       </h3>
       <ResponsiveContainer width="100%" height={350}>
         <PieChart>

--- a/src/pages/manager/VacationStatisticPage.tsx
+++ b/src/pages/manager/VacationStatisticPage.tsx
@@ -3,16 +3,23 @@ import VacationStatisticLayout from "@/layout/VacationStatisticLayout";
 import VacationStatisticContainer from "@/components/container/manager/VacationStatisticContainer";
 import VacationChart from "@/components/company/vacation/VacationChart";
 import VacationStatisticTable from "@/components/company/vacation/VacationStatisticTable";
-
 import { Card } from "@/components/ui/card";
 import VacationPieChart from "@/components/company/vacation/VacationPieChart";
+import { useState } from "react";
 
 const VacationStatisticPage = () => {
+  const today = new Date();
+
+  const [selectedMonth, setSelectedMonth] = useState({
+    year: today.getFullYear(),
+    month: today.getMonth(),
+  });
+
   return (
     <VacationStatisticLayout>
-      <VacationFilter />
+      <VacationFilter selectedMonth={selectedMonth} setSelectedMonth={setSelectedMonth} />
       <VacationStatisticContainer>
-        <VacationChart />
+        <VacationChart selectedMonth={selectedMonth} />
         <div className="flex min-h-[680px] flex-col gap-3 md:flex-row">
           <Card className="hidden h-full items-center justify-center px-4 py-10 md:block md:min-h-[680px] md:w-1/3">
             <VacationPieChart />

--- a/src/pages/manager/VacationStatisticPage.tsx
+++ b/src/pages/manager/VacationStatisticPage.tsx
@@ -10,7 +10,7 @@ import { TEmpUserData } from "@/model/types/user.type";
 
 const VacationStatisticPage = () => {
   const today = new Date();
-  const [selectedMonth, setSelectedMonth] = useState({
+  const [selectedDate, setSelectedDate] = useState({
     year: today.getFullYear(),
     month: today.getMonth(),
   });
@@ -19,15 +19,15 @@ const VacationStatisticPage = () => {
   return (
     <VacationStatisticLayout>
       <VacationFilter
-        selectedMonth={selectedMonth}
-        setSelectedMonth={setSelectedMonth}
+        selectedMonth={selectedDate}
+        setSelectedMonth={setSelectedDate}
         handleNameSelect={setSelectedName}
       />
       <VacationStatisticContainer>
-        <VacationChart selectedMonth={selectedMonth} />
+        <VacationChart selectedDate={selectedDate} selectedName={selectedName} />
         <div className="flex min-h-[680px] flex-col gap-3 md:flex-row">
           <Card className="hidden h-full items-center justify-center px-4 py-10 md:block md:min-h-[680px] md:w-1/3">
-            <VacationPieChart />
+            <VacationPieChart selectedDate={selectedDate} selectedName={selectedName} />
           </Card>
           <VacationStatisticTable />
         </div>

--- a/src/pages/manager/VacationStatisticPage.tsx
+++ b/src/pages/manager/VacationStatisticPage.tsx
@@ -6,18 +6,23 @@ import VacationStatisticTable from "@/components/company/vacation/VacationStatis
 import { Card } from "@/components/ui/card";
 import VacationPieChart from "@/components/company/vacation/VacationPieChart";
 import { useState } from "react";
+import { TEmpUserData } from "@/model/types/user.type";
 
 const VacationStatisticPage = () => {
   const today = new Date();
-
   const [selectedMonth, setSelectedMonth] = useState({
     year: today.getFullYear(),
     month: today.getMonth(),
   });
+  const [selectedName, setSelectedName] = useState<TEmpUserData | null>(null);
 
   return (
     <VacationStatisticLayout>
-      <VacationFilter selectedMonth={selectedMonth} setSelectedMonth={setSelectedMonth} />
+      <VacationFilter
+        selectedMonth={selectedMonth}
+        setSelectedMonth={setSelectedMonth}
+        handleNameSelect={setSelectedName}
+      />
       <VacationStatisticContainer>
         <VacationChart selectedMonth={selectedMonth} />
         <div className="flex min-h-[680px] flex-col gap-3 md:flex-row">


### PR DESCRIPTION
## #️⃣연관된 이슈

> #129 

## 📝작업 내용

> monthpicker 차트에 적용

![Screenshot 2025-03-27 at 6 03 04 PM](https://github.com/user-attachments/assets/32d3583f-283c-4f18-b7e0-38aa01aa6805)

month picker로 월 변경시에 차트 x 축 및 제목에 적용되는 기능 구현

> 직원 검색 시 자동완성

![Screenshot 2025-03-27 at 6 03 52 PM](https://github.com/user-attachments/assets/a7314fd8-6deb-475c-9560-f32b6f05efe2)
직원 이름, 이메일, 직무, 근무 타입 4가지 보여줘서 클릭시에 상세 정보를 보여줄 수 있도록 하였습니다 해당 컴포넌트 재사용할 수 있게 만들어두었으니 휴가 요청 부분에서 사용하시면 될 것 같습니다.

> 차트 클릭시 해당 날짜 상세 정보 보여주는 모달 


## 💬리뷰 요구사항(선택)

> 차트 클릭시 해당 날짜 상세 정보 보여주는 모달 -> api 연동후에 추가 상세한 ui 기능 작업 예정

> 직원 테이블 역시 클릭시 상세 정보 보여줄 수 있는 모달 기획 필요

> api 연동하면서 추가적으로 필요한 ui 작업필요합니다.


