### PR TITLE
[#144] : 직원 휴가 요청 데이터 테스트 (+ 휴가유형 "반차" 선택 시, 날짜 제한)

### DIFF
--- a/src/Components/common/modal/VacationDetailModal.tsx
+++ b/src/Components/common/modal/VacationDetailModal.tsx
@@ -16,8 +16,8 @@ import { useVacationDetailModal } from "@/hooks/manager/useVacationDetailModal";
 interface IVacationDetailModalProps {
   request: IVacationRequest;
   onClose: () => void;
-  onApprove: (id: number) => void;
-  onReject: (id: number) => void;
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
 }
 
 const VacationDetailModal: React.FC<IVacationDetailModalProps> = ({

--- a/src/Components/common/modal/VacationDetailModal.tsx
+++ b/src/Components/common/modal/VacationDetailModal.tsx
@@ -8,7 +8,6 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { IVacationRequest } from "@/components/company/table/VacationColumns";
-import { toast } from "react-toastify";
 import { X } from "lucide-react";
 import { StatusBadge } from "@/components/company/table/VacationColumns";
 import { useVacationDetailModal } from "@/hooks/manager/useVacationDetailModal";

--- a/src/Components/common/modal/VacationRegisterModal.tsx
+++ b/src/Components/common/modal/VacationRegisterModal.tsx
@@ -100,7 +100,13 @@ const VacationRegisterModal: React.FC<IVacationModalProps> = ({ onClose, onRegis
                 {vacationDays > 0 ? `${vacationDays}일` : ""}
               </div>
             </div>
-            <DateRangePicker date={dateRange} setDate={handleDateChange} toDate={maxDate} />
+            <DateRangePicker
+              date={dateRange}
+              setDate={handleDateChange}
+              toDate={maxDate}
+              vacationType={vacationType}
+              handleDateChange={handleDateChange}
+            />
             <p className="text-xs text-gray-500 dark:text-gray-400">
               ※ 휴가 등록은 <strong>최대 3개월</strong> 이후까지만 가능합니다.
             </p>

--- a/src/Components/common/modal/VacationRegisterModal.tsx
+++ b/src/Components/common/modal/VacationRegisterModal.tsx
@@ -40,6 +40,7 @@ const VacationRegisterModal: React.FC<IVacationModalProps> = ({ onClose, onRegis
     setInputValue,
     setSelectedEmployee,
     maxDate,
+    handleDateChange,
   } = useVacationRegister(onRegister, onClose);
 
   const { employeeList } = useEmployeeList();
@@ -86,6 +87,11 @@ const VacationRegisterModal: React.FC<IVacationModalProps> = ({ onClose, onRegis
                 ))}
               </SelectContent>
             </Select>
+            {vacationType === "반차" && (
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                ※ 반차는 하루만 선택할 수 있으며, 오전/오후 선택은 별도 설정 없이 처리됩니다.
+              </p>
+            )}
           </div>
           <div className="flex flex-col gap-2">
             <div className="flex gap-3">
@@ -94,7 +100,7 @@ const VacationRegisterModal: React.FC<IVacationModalProps> = ({ onClose, onRegis
                 {vacationDays > 0 ? `${vacationDays}일` : ""}
               </div>
             </div>
-            <DateRangePicker date={dateRange} setDate={setDateRange} toDate={maxDate} />
+            <DateRangePicker date={dateRange} setDate={handleDateChange} toDate={maxDate} />
             <p className="text-xs text-gray-500 dark:text-gray-400">
               ※ 휴가 등록은 <strong>최대 3개월</strong> 이후까지만 가능합니다.
             </p>

--- a/src/Components/common/modal/VacationRequestModal.tsx
+++ b/src/Components/common/modal/VacationRequestModal.tsx
@@ -1,0 +1,109 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { X } from "lucide-react";
+import { DateRangePicker } from "@/components/ui/date-range-picker";
+import { IVacationRequest } from "@/components/company/table/VacationColumns";
+import { useMyVacationRequestModal } from "@/hooks/employee/useMyVacationRequestModal";
+import { VACATIONSELECT_TYPES } from "@/constants/vacationSelect";
+
+interface IVacationModalProps {
+  onClose: () => void;
+  onRegister: (newRequest: IVacationRequest) => void;
+}
+
+const VacationRequestModal: React.FC<IVacationModalProps> = ({ onClose, onRegister }) => {
+  const {
+    vacationType,
+    setVacationType,
+    dateRange,
+    setDateRange,
+    vacationDays,
+    handleRegister,
+    reason,
+    setReason,
+    maxDate,
+  } = useMyVacationRequestModal(onRegister, onClose);
+
+  return (
+    <Dialog open={true} onOpenChange={onClose}>
+      <DialogContent className="dark:border dark:border-dark-border sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex justify-center dark:text-white-text">휴가 요청</DialogTitle>
+          <button
+            onClick={onClose}
+            className="absolute right-4 top-7 rounded-md border-none bg-transparent text-gray-500 hover:text-gray-700 dark:text-white-text dark:hover:bg-dark-border dark:hover:bg-white-bg"
+          >
+            <X size={20} strokeWidth={3} />
+          </button>
+        </DialogHeader>
+
+        <div className="grid gap-8 py-6">
+          <div className="flex flex-col gap-2">
+            <span className="font-medium">휴가 유형</span>
+            <Select value={vacationType} onValueChange={setVacationType}>
+              <SelectTrigger className="dark:text-white-text">
+                <SelectValue placeholder="휴가 유형 선택" />
+              </SelectTrigger>
+              <SelectContent className="dark:border dark:border-dark-border dark:bg-white-card-bg dark:text-white-text">
+                {VACATIONSELECT_TYPES.map(type => (
+                  <SelectItem
+                    key={type}
+                    value={type}
+                    className="dark:text-white-text dark:hover:bg-white-bg"
+                  >
+                    {type}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex flex-col gap-2">
+            <div className="flex gap-3">
+              <span className="font-medium">사용 기간 :</span>
+              <div className="rounded-md border dark:border-dark-border dark:bg-white-bg">
+                {vacationDays > 0 ? `${vacationDays}일` : ""}
+              </div>
+            </div>
+            <DateRangePicker date={dateRange} setDate={setDateRange} toDate={maxDate} />
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              ※ 휴가 등록은 <strong>최대 3개월</strong> 이후까지만 가능합니다.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2">
+            <span>사유</span>
+            <textarea
+              className="h-20 w-full rounded-md text-base"
+              value={reason}
+              onChange={e => setReason(e.target.value)}
+            ></textarea>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="submit"
+            className="w-full dark:bg-dark-bg dark:text-dark-text"
+            onClick={handleRegister}
+          >
+            등록
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default VacationRequestModal;

--- a/src/Components/common/modal/VacationRequestModal.tsx
+++ b/src/Components/common/modal/VacationRequestModal.tsx
@@ -30,12 +30,13 @@ const VacationRequestModal: React.FC<IVacationModalProps> = ({ onClose, onRegist
     setVacationType,
     dateRange,
     setDateRange,
+    handleDateChange,
     vacationDays,
     handleRegister,
     reason,
     setReason,
     maxDate,
-  } = useMyVacationRequestModal(onRegister, onClose);
+  } = useMyVacationRequestModal(onRegister, onClose)!;
 
   return (
     <Dialog open={true} onOpenChange={onClose}>
@@ -69,6 +70,11 @@ const VacationRequestModal: React.FC<IVacationModalProps> = ({ onClose, onRegist
                 ))}
               </SelectContent>
             </Select>
+            {vacationType === "반차" && (
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                ※ 반차는 하루만 선택할 수 있으며, 오전/오후 선택은 별도 설정 없이 처리됩니다.
+              </p>
+            )}
           </div>
           <div className="flex flex-col gap-2">
             <div className="flex gap-3">
@@ -77,7 +83,7 @@ const VacationRequestModal: React.FC<IVacationModalProps> = ({ onClose, onRegist
                 {vacationDays > 0 ? `${vacationDays}일` : ""}
               </div>
             </div>
-            <DateRangePicker date={dateRange} setDate={setDateRange} toDate={maxDate} />
+            <DateRangePicker date={dateRange} setDate={handleDateChange} toDate={maxDate} />
             <p className="text-xs text-gray-500 dark:text-gray-400">
               ※ 휴가 등록은 <strong>최대 3개월</strong> 이후까지만 가능합니다.
             </p>

--- a/src/Components/common/modal/VacationRequestModal.tsx
+++ b/src/Components/common/modal/VacationRequestModal.tsx
@@ -83,7 +83,13 @@ const VacationRequestModal: React.FC<IVacationModalProps> = ({ onClose, onRegist
                 {vacationDays > 0 ? `${vacationDays}일` : ""}
               </div>
             </div>
-            <DateRangePicker date={dateRange} setDate={handleDateChange} toDate={maxDate} />
+            <DateRangePicker
+              date={dateRange}
+              setDate={handleDateChange}
+              toDate={maxDate}
+              vacationType={vacationType}
+              handleDateChange={handleDateChange}
+            />
             <p className="text-xs text-gray-500 dark:text-gray-400">
               ※ 휴가 등록은 <strong>최대 3개월</strong> 이후까지만 가능합니다.
             </p>

--- a/src/Components/company/table/VacationColumns.tsx
+++ b/src/Components/company/table/VacationColumns.tsx
@@ -2,9 +2,14 @@ import { ColumnDef } from "@tanstack/react-table";
 import { Button } from "@/components/ui/button";
 
 export interface IVacationRequest {
-  id: number;
+  id: string;
   requestType: string;
-  requester: string;
+  requester: {
+    name: string;
+    email: string;
+    uid?: string;
+    jobName?: string;
+  };
   requestDate: string;
   reason: string;
   status: "대기중" | "승인" | "거절" | "자동 승인";
@@ -36,8 +41,8 @@ export const getVacationColumns = ({
   includeActions = true,
   isRegistered = false,
 }: {
-  onApprove?: (id: number) => void;
-  onReject?: (id: number) => void;
+  onApprove?: (id: string) => void | Promise<void>;
+  onReject?: (id: string) => void | Promise<void>;
   includeActions?: boolean;
   isRegistered?: boolean;
 }): ColumnDef<IVacationRequest>[] => {
@@ -48,8 +53,9 @@ export const getVacationColumns = ({
       cell: ({ getValue }) => <span>{getValue() as string}</span>,
     },
     {
-      accessorKey: "requester",
       header: "휴가자",
+      accessorFn: row => row.requester.name,
+      id: "requester",
       cell: ({ getValue }) => <span>{getValue() as string}</span>,
     },
     {

--- a/src/Components/company/table/VacationColumns.tsx
+++ b/src/Components/company/table/VacationColumns.tsx
@@ -61,7 +61,16 @@ export const getVacationColumns = ({
     {
       accessorKey: "requestDate",
       header: "휴가 일자",
-      cell: ({ getValue }) => <span>{getValue() as string}</span>,
+      cell: ({ getValue }) => {
+        const value = getValue() as string;
+
+        if (value.includes("~")) {
+          const [from, to] = value.split(" ~ ");
+          return from === to ? <span>{from}</span> : <span>{value}</span>;
+        }
+
+        return <span>{value}</span>;
+      },
     },
     {
       accessorKey: "reason",

--- a/src/Components/company/table/VacationColumns.tsx
+++ b/src/Components/company/table/VacationColumns.tsx
@@ -14,6 +14,7 @@ export interface IVacationRequest {
   reason: string;
   status: "대기중" | "승인" | "거절" | "자동 승인";
   email?: string;
+  processedAt?: string;
 }
 
 // 상태 배지 컴포넌트

--- a/src/Components/ui/date-range-picker.tsx
+++ b/src/Components/ui/date-range-picker.tsx
@@ -34,9 +34,13 @@ export function DateRangePicker({
             <CalendarIcon size={18} />
             {date?.from ? (
               date.to ? (
-                <>
-                  {format(date.from, "yyyy-MM-dd")} ~ {format(date.to, "yyyy-MM-dd")}
-                </>
+                format(date.from, "yyyy-MM-dd") === format(date.to, "yyyy-MM-dd") ? (
+                  format(date.from, "yyyy-MM-dd")
+                ) : (
+                  <>
+                    {format(date.from, "yyyy-MM-dd")} ~ {format(date.to, "yyyy-MM-dd")}
+                  </>
+                )
               ) : (
                 format(date.from, "yyyy-MM-dd")
               )

--- a/src/Components/ui/date-range-picker.tsx
+++ b/src/Components/ui/date-range-picker.tsx
@@ -13,11 +13,15 @@ export function DateRangePicker({
   setDate,
   className,
   toDate,
+  vacationType,
+  handleDateChange,
 }: {
   date: DateRange | undefined;
   setDate: React.Dispatch<React.SetStateAction<DateRange | undefined>>;
   className?: string;
   toDate?: Date;
+  vacationType: string;
+  handleDateChange: (range: DateRange | undefined) => void;
 }) {
   return (
     <div className={cn("grid gap-2", className)}>
@@ -50,15 +54,27 @@ export function DateRangePicker({
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-auto p-0" align="start">
-          <Calendar
-            initialFocus
-            mode="range"
-            defaultMonth={date?.from}
-            selected={date}
-            onSelect={setDate}
-            numberOfMonths={2} // 두 달짜리 캘린더
-            toDate={toDate}
-          />
+          {vacationType === "반차" ? (
+            <Calendar
+              initialFocus
+              mode="single"
+              defaultMonth={date?.from}
+              selected={date?.from}
+              onSelect={day => handleDateChange(day ? { from: day, to: day } : undefined)}
+              numberOfMonths={1}
+              toDate={toDate}
+            />
+          ) : (
+            <Calendar
+              initialFocus
+              mode="range"
+              defaultMonth={date?.from}
+              selected={date}
+              onSelect={handleDateChange}
+              numberOfMonths={2}
+              toDate={toDate}
+            />
+          )}
         </PopoverContent>
       </Popover>
     </div>

--- a/src/api/vacation.api.ts
+++ b/src/api/vacation.api.ts
@@ -7,7 +7,7 @@ import {
   getVacationRequestListPath,
 } from "@/constants/api.path";
 
-// 휴가 요청 (현재 사용 x, 추후 기능 추가 예정)
+// 휴가 요청 생성
 export const createVacationRequest = (
   companyCode: string,
   requestId: string,
@@ -17,17 +17,17 @@ export const createVacationRequest = (
   return setData(path, data, "휴가 요청이 등록되었습니다.");
 };
 
-// 휴가 요청 조회 (현재 사용 x, 추후 기능 추가 예정)
+// 휴가 요청 조회
 export const fetchVacationRequests = (companyCode: string) => {
   const path = getVacationRequestListPath(companyCode);
   return getData<Record<string, TVacationRequest>>(path);
 };
 
-// 휴가 요청 상태 업데이트 (현재 사용 x, 추후 기능 추가 예정)
+// 휴가 요청 상태 업데이트
 export const updateVacationRequestStatus = (
   companyCode: string,
   requestId: string,
-  status: "승인됨" | "거절됨",
+  status: "승인" | "거절",
   processedAt: string = new Date().toISOString(),
 ) => {
   const path = `${getVacationRequestListPath(companyCode)}/${requestId}`;
@@ -97,4 +97,3 @@ export async function fetchRegisteredVacationsByMonth(
 
   return await getData(path);
 }
-

--- a/src/hooks/employee/useMyVacation.ts
+++ b/src/hooks/employee/useMyVacation.ts
@@ -1,0 +1,32 @@
+import { useState } from "react";
+import { IVacationRequest } from "@/components/company/table/VacationColumns";
+import { setData } from "@/api";
+import { useUserStore } from "@/store/user.store";
+import { v4 as uuid } from "uuid";
+
+export const useMyVacation = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const companyCode = useUserStore(state => state.currentUser?.companyCode);
+
+  const toggleModal = () => setIsModalOpen(prev => !prev);
+
+  const handleRequest = async (newRequest: IVacationRequest) => {
+    if (!companyCode) return;
+
+    const dataWithStatus = {
+      ...newRequest,
+      status: "대기중",
+      createdAt: Date.now(),
+    };
+
+    const id = uuid();
+    await setData(`vacation/requests/${companyCode}/${id}`, dataWithStatus);
+    console.log("🔥 요청 저장됨:", dataWithStatus);
+  };
+
+  return {
+    isModalOpen,
+    toggleModal,
+    handleRequest,
+  };
+};

--- a/src/hooks/employee/useMyVacationRequestModal.ts
+++ b/src/hooks/employee/useMyVacationRequestModal.ts
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import { DateRange } from "react-day-picker";
+import { differenceInDays, format } from "date-fns";
+import { IVacationRequest } from "@/components/company/table/VacationColumns";
+import { TVacationType } from "@/model/types/vacation.type";
+import { useToast } from "../use-toast";
+import { useUserStore } from "@/store/user.store";
+import { v4 as uuid } from "uuid";
+import { createVacationRequest } from "@/api/vacation.api";
+
+export const useMyVacationRequestModal = (
+  onRequest: (newRequest: IVacationRequest) => void,
+  onClose: () => void,
+) => {
+  const [vacationType, setVacationType] = useState("");
+  const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined);
+  const [reason, setReason] = useState("");
+  const { toast } = useToast();
+  const currentUser = useUserStore(state => state.currentUser);
+
+  const maxDate = new Date();
+  maxDate.setMonth(maxDate.getMonth() + 3);
+
+  const vacationDays =
+    dateRange?.from && dateRange?.to ? differenceInDays(dateRange.to, dateRange.from) + 1 : 0;
+
+  const handleRegister = async () => {
+    if (!vacationType || !dateRange?.from || !dateRange?.to || !reason) {
+      toast({
+        title: "등록 실패",
+        description: "모든 항목을 입력해주세요.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (!currentUser || !("jobName" in currentUser)) {
+      toast({
+        title: "등록 실패",
+        description: "직원 정보가 올바르지 않습니다.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const requestId = uuid();
+
+    await createVacationRequest(currentUser.companyCode, requestId, {
+      requestId,
+      requester: {
+        uid: currentUser.uid,
+        name: currentUser.name,
+        email: currentUser.email,
+        jobName: currentUser.jobName,
+      },
+      vacationType: vacationType as TVacationType,
+      startDate: format(dateRange.from, "yyyy-MM-dd"),
+      endDate: format(dateRange.to, "yyyy-MM-dd"),
+      reason,
+      status: "대기중",
+      createdAt: new Date().toISOString(),
+    });
+
+    const newRequest: IVacationRequest = {
+      id: String(Date.now()),
+      requestType: vacationType as TVacationType,
+      requester: {
+        name: currentUser.name,
+        email: currentUser.email,
+        uid: currentUser.uid,
+        jobName: currentUser.jobName,
+      },
+      requestDate: `${format(dateRange.from, "yyyy-MM-dd")} ~ ${format(dateRange.to, "yyyy-MM-dd")}`,
+      reason,
+      status: "대기중",
+      email: currentUser.email,
+    };
+
+    onRequest(newRequest);
+    toast({
+      title: "휴가 요청 완료",
+      description: "휴가 요청이 정상적으로 등록되었습니다.",
+    });
+    onClose();
+  };
+
+  return {
+    vacationType,
+    setVacationType,
+    dateRange,
+    setDateRange,
+    vacationDays,
+    reason,
+    setReason,
+    maxDate,
+    handleRegister,
+  };
+};

--- a/src/hooks/employee/useMyVacationRequestModal.ts
+++ b/src/hooks/employee/useMyVacationRequestModal.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { DateRange } from "react-day-picker";
 import { differenceInDays, format } from "date-fns";
 import { IVacationRequest } from "@/components/company/table/VacationColumns";
@@ -70,7 +70,11 @@ export const useMyVacationRequestModal = (
         uid: currentUser.uid,
         jobName: currentUser.jobName,
       },
-      requestDate: `${format(dateRange.from, "yyyy-MM-dd")} ~ ${format(dateRange.to, "yyyy-MM-dd")}`,
+      requestDate:
+        vacationType === "반차" ||
+        format(dateRange.from, "yyyy-MM-dd") === format(dateRange.to, "yyyy-MM-dd")
+          ? format(dateRange.from, "yyyy-MM-dd")
+          : `${format(dateRange.from, "yyyy-MM-dd")} ~ ${format(dateRange.to, "yyyy-MM-dd")}`,
       reason,
       status: "대기중",
       email: currentUser.email,
@@ -84,6 +88,24 @@ export const useMyVacationRequestModal = (
     onClose();
   };
 
+  const handleDateChange: React.Dispatch<React.SetStateAction<DateRange | undefined>> = value => {
+    const range = typeof value === "function" ? value(undefined) : value;
+    if (!range?.from) return;
+
+    if (vacationType === "반차") {
+      setDateRange({ from: range.from, to: range.from });
+    } else {
+      setDateRange(range);
+    }
+  };
+
+  // "반차"일 경우 하루 고정
+  useEffect(() => {
+    if (vacationType === "반차" && dateRange?.from) {
+      setDateRange({ from: dateRange.from, to: dateRange.from });
+    }
+  }, [vacationType, dateRange?.from]);
+
   return {
     vacationType,
     setVacationType,
@@ -94,5 +116,6 @@ export const useMyVacationRequestModal = (
     setReason,
     maxDate,
     handleRegister,
+    handleDateChange,
   };
 };

--- a/src/hooks/manager/useVacationDetailModal.ts
+++ b/src/hooks/manager/useVacationDetailModal.ts
@@ -10,11 +10,18 @@ export const useVacationDetailModal = (
   const { toast } = useToast();
   const isPending = request.status === "대기중";
 
+  const displayRequestDate = request.requestDate.includes("~")
+    ? (() => {
+        const [from, to] = request.requestDate.split(" ~ ");
+        return from === to ? from : request.requestDate;
+      })()
+    : request.requestDate;
+
   const detailRows = [
     { label: "휴가자", value: request.requester.name },
     { label: "휴가 유형", value: request.requestType },
     { label: "이메일", value: request.email ?? "-" },
-    { label: "휴가 일자", value: request.requestDate },
+    { label: "휴가 일자", value: displayRequestDate },
   ];
 
   const handleApproveClick = () => {

--- a/src/hooks/manager/useVacationDetailModal.ts
+++ b/src/hooks/manager/useVacationDetailModal.ts
@@ -3,15 +3,15 @@ import { useToast } from "../use-toast";
 
 export const useVacationDetailModal = (
   request: IVacationRequest,
-  onApprove: (id: number) => void,
-  onReject: (id: number) => void,
+  onApprove: (id: string) => void,
+  onReject: (id: string) => void,
   onClose: () => void,
 ) => {
   const { toast } = useToast();
   const isPending = request.status === "대기중";
 
   const detailRows = [
-    { label: "휴가자", value: request.requester },
+    { label: "휴가자", value: request.requester.name },
     { label: "휴가 유형", value: request.requestType },
     { label: "이메일", value: request.email ?? "-" },
     { label: "휴가 일자", value: request.requestDate },
@@ -21,7 +21,7 @@ export const useVacationDetailModal = (
     onApprove(request.id);
     toast({
       title: "승인 처리 완료",
-      description: `${request.requester}님의 휴가 요청을 승인했습니다.`,
+      description: `${request.requester.name}님의 휴가 요청을 승인했습니다.`,
       variant: "destructive",
     });
     onClose();
@@ -31,7 +31,7 @@ export const useVacationDetailModal = (
     onReject(request.id);
     toast({
       title: "거절 처리 완료",
-      description: `${request.requester}님의 휴가 요청을 거절했습니다.`,
+      description: `${request.requester.name}님의 휴가 요청을 거절했습니다.`,
       variant: "destructive",
     });
     onClose();

--- a/src/hooks/manager/useVacationRegisterModal.ts
+++ b/src/hooks/manager/useVacationRegisterModal.ts
@@ -66,9 +66,14 @@ export const useVacationRegister = (
     }
 
     const newRequest: IVacationRequest = {
-      id: Date.now(),
+      id: String(Date.now()),
       requestType: vacationType as TVacationType,
-      requester: selectedEmployee.name,
+      requester: {
+        name: selectedEmployee.name,
+        email: selectedEmployee.email,
+        uid: selectedEmployee.uid,
+        jobName: selectedEmployee.jobName,
+      },
       requestDate: `${dateRange.from.toISOString().split("T")[0]} ~ ${dateRange.to.toISOString().split("T")[0]}`,
       reason,
       status: "자동 승인",
@@ -107,6 +112,24 @@ export const useVacationRegister = (
     onClose();
   };
 
+  const handleDateChange: React.Dispatch<React.SetStateAction<DateRange | undefined>> = value => {
+    const range = typeof value === "function" ? value(undefined) : value;
+    if (!range?.from) return;
+
+    if (vacationType === "반차") {
+      setDateRange({ from: range.from, to: range.from });
+    } else {
+      setDateRange(range);
+    }
+  };
+
+  // "반차"일 경우 하루 고정
+  useEffect(() => {
+    if (vacationType === "반차" && dateRange?.from) {
+      setDateRange({ from: dateRange.from, to: dateRange.from });
+    }
+  }, [vacationType, dateRange?.from]);
+
   return {
     vacationType,
     setVacationType,
@@ -125,5 +148,6 @@ export const useVacationRegister = (
     setSelectedEmployee,
     dropdownRef,
     maxDate,
+    handleDateChange,
   };
 };

--- a/src/hooks/manager/useVacationRequests.ts
+++ b/src/hooks/manager/useVacationRequests.ts
@@ -1,14 +1,17 @@
 import { useEffect, useState } from "react";
 import { IVacationRequest } from "@/components/company/table/VacationColumns";
 import { useUserStore } from "@/store/user.store";
-import { fetchVacationRegistered } from "@/api/vacation.api";
-import { DUMMY_VACATION_REQUESTS } from "@/constants/dummyVacationRequests";
+import {
+  fetchVacationRegistered,
+  fetchVacationRequests,
+  updateVacationRequestStatus,
+} from "@/api/vacation.api";
 
 export const useVacationRequests = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   // 더미데이터 사용시
-  const [requests, setRequests] = useState<IVacationRequest[]>(DUMMY_VACATION_REQUESTS);
-  // const [requests, setRequests] = useState<IVacationRequest[]>([]);
+  // const [requests, setRequests] = useState<IVacationRequest[]>(DUMMY_VACATION_REQUESTS);
+  const [requests, setRequests] = useState<IVacationRequest[]>([]);
   const [registeredRequests, setRegisteredRequests] = useState<IVacationRequest[]>([]);
   const [selectedRequest, setSelectedRequest] = useState<IVacationRequest | null>(null);
   const [page, setPage] = useState<Record<string, number>>({
@@ -16,6 +19,8 @@ export const useVacationRequests = () => {
     processed: 0,
     registered: 0,
   });
+  const [activeTab, setActiveTab] = useState("pending");
+
   const companyCode = useUserStore(state => state.currentUser?.companyCode);
   const itemsPerPage = 10;
   const pendingCount = requests.filter(req => req.status === "대기중").length;
@@ -42,15 +47,57 @@ export const useVacationRequests = () => {
   const handleRegister = (newRequest: IVacationRequest) => {
     setRegisteredRequests(prev => [...prev, newRequest]);
   };
-  const handleApprove = (id: number) => {
-    setRequests(prev => prev.map(req => (req.id === id ? { ...req, status: "승인" } : req)));
+
+  const handleApprove = async (id: string) => {
+    if (!companyCode) return;
+
+    await updateVacationRequestStatus(companyCode, id, "승인");
+
+    setRequests(prev =>
+      prev.map(req => (req.id === id ? { ...req, status: "승인" as const } : req)),
+    );
   };
-  const handleReject = (id: number) => {
-    setRequests(prev => prev.map(req => (req.id === id ? { ...req, status: "거절" } : req)));
+  const handleReject = async (id: string) => {
+    if (!companyCode) return;
+
+    await updateVacationRequestStatus(companyCode, id, "거절");
+
+    setRequests(prev =>
+      prev.map(req => (req.id === id ? { ...req, status: "거절" as const } : req)),
+    );
   };
+
   const handleRowClick = (request: IVacationRequest | null) => {
     setSelectedRequest(request);
   };
+
+  useEffect(() => {
+    const loadRequests = async () => {
+      if (!companyCode) return;
+      const snapshot = await fetchVacationRequests(companyCode);
+
+      if (!snapshot) return;
+
+      const mapped: IVacationRequest[] = Object.entries(snapshot).map(([id, item]) => ({
+        id,
+        requestType: item.vacationType,
+        requester: {
+          name: item.requester.name,
+          email: item.requester.email,
+          uid: item.requester.uid,
+          jobName: item.requester.jobName,
+        },
+        requestDate: `${item.startDate} ~ ${item.endDate}`,
+        reason: item.reason,
+        status: item.status === "승인" ? "승인" : item.status === "거절" ? "거절" : "대기중",
+        email: item.requester.email,
+      }));
+
+      setRequests(mapped);
+    };
+
+    loadRequests();
+  }, [companyCode]);
 
   useEffect(() => {
     const loadRegistered = async () => {
@@ -61,9 +108,13 @@ export const useVacationRequests = () => {
         const status: IVacationRequest["status"] = "자동 승인"; // 등록은 무조건 자동 승인
 
         return {
-          id: idx + 1,
+          id: String(idx + 1),
           requestType: item.vacationType,
-          requester: item.name,
+          requester: {
+            name: item.name,
+            email: item.email,
+            jobName: item.jobName,
+          },
           requestDate: `${item.startDate} ~ ${item.endDate}`,
           reason: item.reason,
           status,
@@ -119,6 +170,10 @@ export const useVacationRequests = () => {
     selection: {
       selected: selectedRequest,
       select: handleRowClick,
+    },
+    tab: {
+      active: activeTab,
+      setActive: setActiveTab,
     },
   };
 };

--- a/src/hooks/manager/useVacationRequests.ts
+++ b/src/hooks/manager/useVacationRequests.ts
@@ -104,23 +104,23 @@ export const useVacationRequests = () => {
       if (!companyCode) return;
       const data = await fetchVacationRegistered(companyCode);
 
-      const mapped: IVacationRequest[] = data.map((item, idx) => {
-        const status: IVacationRequest["status"] = "자동 승인"; // 등록은 무조건 자동 승인
-
-        return {
-          id: String(idx + 1),
-          requestType: item.vacationType,
-          requester: {
-            name: item.name,
+      const mapped = data
+        .map(item => {
+          const status: IVacationRequest["status"] = "자동 승인";
+          return {
+            id: item.createdAt ?? new Date().toISOString(),
+            requestType: item.vacationType,
+            requester: {
+              name: item.name,
+              email: item.email,
+            },
+            requestDate: `${item.startDate} ~ ${item.endDate}`,
+            reason: item.reason,
+            status,
             email: item.email,
-            jobName: item.jobName,
-          },
-          requestDate: `${item.startDate} ~ ${item.endDate}`,
-          reason: item.reason,
-          status,
-          email: item.email,
-        };
-      });
+          };
+        })
+        .sort((a, b) => new Date(b.id).getTime() - new Date(a.id).getTime());
       setRegisteredRequests(mapped);
     };
 

--- a/src/hooks/manager/useVacationRequests.ts
+++ b/src/hooks/manager/useVacationRequests.ts
@@ -51,19 +51,22 @@ export const useVacationRequests = () => {
   const handleApprove = async (id: string) => {
     if (!companyCode) return;
 
-    await updateVacationRequestStatus(companyCode, id, "승인");
+    const processedAt = new Date().toISOString();
+    await updateVacationRequestStatus(companyCode, id, "승인", processedAt);
 
     setRequests(prev =>
-      prev.map(req => (req.id === id ? { ...req, status: "승인" as const } : req)),
+      prev.map(req => (req.id === id ? { ...req, status: "승인", processedAt } : req)),
     );
   };
+
   const handleReject = async (id: string) => {
     if (!companyCode) return;
 
-    await updateVacationRequestStatus(companyCode, id, "거절");
+    const processedAt = new Date().toISOString();
+    await updateVacationRequestStatus(companyCode, id, "거절", processedAt);
 
     setRequests(prev =>
-      prev.map(req => (req.id === id ? { ...req, status: "거절" as const } : req)),
+      prev.map(req => (req.id === id ? { ...req, status: "거절", processedAt } : req)),
     );
   };
 
@@ -91,6 +94,7 @@ export const useVacationRequests = () => {
         reason: item.reason,
         status: item.status === "승인" ? "승인" : item.status === "거절" ? "거절" : "대기중",
         email: item.requester.email,
+        processedAt: item.processedAt,
       }));
 
       setRequests(mapped);
@@ -134,14 +138,17 @@ export const useVacationRequests = () => {
     if (tabValue === "registered") return registeredRequests;
 
     if (tabValue === "processed") {
-      return requests
-        .filter(filter)
-        .sort(
-          (a, b) =>
-            new Date(b.requestDate.split(" ~ ")[0]).getTime() -
-            new Date(a.requestDate.split(" ~ ")[0]).getTime(),
-        );
+      return requests.filter(filter).sort((a, b) => {
+        const aTime = a.processedAt
+          ? new Date(a.processedAt).getTime()
+          : new Date(a.requestDate.split(" ~ ")[0]).getTime();
+        const bTime = b.processedAt
+          ? new Date(b.processedAt).getTime()
+          : new Date(b.requestDate.split(" ~ ")[0]).getTime();
+        return bTime - aTime;
+      });
     }
+
     return requests.filter(filter);
   };
 

--- a/src/model/types/vacation.type.ts
+++ b/src/model/types/vacation.type.ts
@@ -2,7 +2,7 @@ import { TJobList, TSelectableJobName } from "./company.type";
 import { TUserBase } from "./user.type";
 
 export type TVacationType = "반차" | "연차" | "특별";
-export type TVacationStatus = "대기중" | "승인됨" | "거절됨" | "자동 승인됨";
+export type TVacationStatus = "대기중" | "승인" | "거절" | "자동 승인";
 
 // 휴가 요청 타입
 export type TVacationRequest<T extends TJobList = TJobList> = {

--- a/src/pages/employee/MyVacationPage.tsx
+++ b/src/pages/employee/MyVacationPage.tsx
@@ -1,7 +1,29 @@
-import React from "react";
+import { Button } from "@/components/ui/button";
+import { IVacationRequest } from "@/components/company/table/VacationColumns";
+import { useMyVacation } from "@/hooks/employee/useMyVacation";
+import { useVacationRequests } from "@/hooks/manager/useVacationRequests";
+import VacationRequestModal from "@/components/common/modal/VacationRequestModal";
 
 const MyVacationPage = () => {
-  return <div>MyVacationPage</div>;
+  const { isModalOpen, toggleModal } = useMyVacation();
+  const { requests } = useVacationRequests();
+  const { register: handleRequest } = requests;
+
+  const handleSubmit = (data: IVacationRequest) => {
+    handleRequest(data);
+  };
+
+  return (
+    <div className="p-3">
+      <div>
+        <Button className="w-full cursor-pointer" onClick={toggleModal}>
+          휴가 요청
+        </Button>
+      </div>
+
+      {isModalOpen && <VacationRequestModal onClose={toggleModal} onRegister={handleSubmit} />}
+    </div>
+  );
 };
 
 export default MyVacationPage;

--- a/src/pages/manager/VacationDetailPage.tsx
+++ b/src/pages/manager/VacationDetailPage.tsx
@@ -28,14 +28,18 @@ const VacationDetailPage = () => {
       getCurrentPageData,
     },
     selection: { selected: selectedRequest, select: handleRowClick },
+    tab: { active: activeTab, setActive: setActiveTab },
   } = useVacationRequests();
 
   return (
     <VacationRequestPageContainer>
       <Tabs
-        defaultValue="pending"
+        value={activeTab}
         className="w-full"
-        onValueChange={tab => setPage(prev => ({ ...prev, [tab]: 0 }))}
+        onValueChange={tab => {
+          setActiveTab(tab);
+          setPage(prev => ({ ...prev, [tab]: 0 }));
+        }}
       >
         <div className="flex justify-between bg-white-bg dark:bg-dark-bg">
           <TabsList className="flex h-12 w-full justify-start bg-white-bg py-1 dark:bg-dark-bg">
@@ -95,8 +99,16 @@ const VacationDetailPage = () => {
         <VacationDetailModal
           request={selectedRequest}
           onClose={() => handleRowClick(null)}
-          onApprove={handleApprove}
-          onReject={handleReject}
+          onApprove={id => {
+            handleApprove(String(id));
+            setActiveTab("processed");
+            setPage(prev => ({ ...prev, processed: 0 }));
+          }}
+          onReject={id => {
+            handleReject(String(id));
+            setActiveTab("processed");
+            setPage(prev => ({ ...prev, processed: 0 }));
+          }}
         />
       )}
     </VacationRequestPageContainer>

--- a/src/pages/manager/VacationDetailPage.tsx
+++ b/src/pages/manager/VacationDetailPage.tsx
@@ -47,7 +47,7 @@ const VacationDetailPage = () => {
               <TabsTrigger
                 key={tab.value}
                 value={tab.value}
-                className="h-13 relative mt-2 min-w-[80px] max-w-[200px] flex-1 rounded-t-lg border-none text-center text-sm font-semibold text-white-text data-[state=active]:text-black dark:bg-dark-bg dark:text-white-bg dark:data-[state=active]:bg-dark-card-bg dark:data-[state=active]:text-white-bg sm:px-6 sm:py-3 sm:text-base"
+                className="relative mt-4 h-12 min-w-[80px] max-w-[200px] flex-1 rounded-t-lg border-none text-center text-sm font-semibold text-white-text data-[state=active]:text-black dark:bg-dark-bg dark:text-white-bg dark:data-[state=active]:bg-dark-card-bg dark:data-[state=active]:text-white-bg sm:px-6 sm:py-3 sm:text-base"
               >
                 <span className="flex items-center justify-center gap-1 pt-2">
                   {tab.label}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #144 

## 📝작업 내용

> 휴가 요청 데이터 테스트
- 직원 휴가 페이지에 임시로 버튼을 생성 후 요청 모달을 띄웠습니다.
<img width="381" alt="스크린샷 2025-04-02 오전 2 38 50" src="https://github.com/user-attachments/assets/9b73a40c-9f69-48be-ac33-ff632fac6670" /><br/><br/>

- 요청된 직원의 휴가 데이터
![스크린샷 2025-04-02 오전 2 39 55](https://github.com/user-attachments/assets/e054957c-e887-4329-a1e7-50ca3f6e56f7)
<br/><br/>
- 상세 모달에서 승인 or 거절버튼을 누르고 나면 최신순으로 처리 내역 탭에 저장
![스크린샷 2025-04-02 오전 2 59 30](https://github.com/user-attachments/assets/4569640b-791f-4645-b476-47c980ff1fe2)

> 등록/요청 모달에 있는 휴가 유형 "반차" 선택 시, 날짜 선택 제한 로직 추가
- "반차" 유형을 선택하면 밑에 주의사항 텍스트와 함께 켈린더에서는 하루만 선택하게끔 변경
![스크린샷 2025-04-02 오전 3 01 43](https://github.com/user-attachments/assets/ef294b33-e0ab-407f-9810-a2ab37177767)
<br/><br/>

- 핫픽스) 하루 날짜 선택하면 "날짜~날짜" 형식이 아닌 한 날짜만 나오도록 수정
![스크린샷 2025-04-02 오전 3 03 04](https://github.com/user-attachments/assets/388bccfb-d1d4-4f3b-99ad-81e4f14f489b)


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 원래는 요청 테스트만 pr을 올리려 했으나 테스트가 일찍 끝나기도 했고 어차피 다른 페이지 작업도 빨리 해야되니 관리자 휴가부분은 기능적인 것은 이부분만 마무리하면 되기 때문에 한번에 작업했습니다.