### PR TITLE
[#146] : 직원 휴가 페이지 상세 ui (더미데이터 있음)

### DIFF
--- a/src/Components/common/modal/EmployeeVacationDetailModal.tsx
+++ b/src/Components/common/modal/EmployeeVacationDetailModal.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { TVacationRequest } from "@/model/types/vacation.type";
+import { Calendar, User, BadgeCheck, FileText, PlaneTakeoff } from "lucide-react";
+
+const VACATION_TYPE_CLASSES: Record<string, string> = {
+  연차: "bg-[#0F4C75]",
+  반차: "bg-[#3282B8]",
+  "특별 휴가": "bg-[#BBE1FA] text-black",
+};
+
+const VACATION_STATUS_CLASSES: Record<string, string> = {
+  승인됨: "bg-green-500",
+  거절됨: "bg-red-500",
+  대기중: "bg-yellow-500",
+};
+
+interface TEmployeeVacationDetailModalProps {
+  modalOpen: boolean;
+  setModalOpen: (open: boolean) => void;
+  request: TVacationRequest;
+  start: string;
+  end: string;
+  isSameDay: boolean;
+  label: string;
+}
+
+const EmployeeVacationDetailModal = ({
+  modalOpen,
+  setModalOpen,
+  request,
+  start,
+  end,
+  isSameDay,
+  label,
+}: TEmployeeVacationDetailModalProps) => {
+  const badgeTypeClass = VACATION_TYPE_CLASSES[request.vacationType] || "bg-gray-400";
+  const badgeStatusClass = VACATION_STATUS_CLASSES[label] || "bg-gray-400";
+
+  return (
+    <Dialog open={modalOpen} onOpenChange={setModalOpen}>
+      <DialogContent className="w-[90vw] max-w-md dark:text-white-text">
+        <DialogHeader>
+          <DialogTitle className="flex items-center justify-between gap-2 text-lg dark:text-gray-900">
+            <div className="flex items-center gap-2">
+              <PlaneTakeoff className="h-5 w-5 text-primary dark:text-gray-900" /> 휴가 상세 정보
+            </div>
+            <div className="flex flex-wrap items-center justify-center gap-2">
+              <span
+                className={`rounded-full px-3 py-1 text-xs font-semibold text-white ${badgeTypeClass}`}
+              >
+                {request.vacationType}
+              </span>
+              <span
+                className={`rounded-full px-3 py-1 text-xs font-semibold text-white ${badgeStatusClass}`}
+              >
+                {label}
+              </span>
+            </div>
+          </DialogTitle>
+        </DialogHeader>
+
+        {/* 상단 뱃지 정보 */}
+
+        {/* 세부 정보 */}
+        <div className="mt-6 space-y-4 text-sm text-foreground dark:text-gray-900">
+          <div className="flex items-center gap-2">
+            <User className="h-4 w-4 text-muted-foreground" />
+            <span className="font-medium">이름:</span> {request.requester.name}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <BadgeCheck className="h-4 w-4 text-muted-foreground" />
+            <span className="font-medium">직무:</span> {request.requester.jobName}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Calendar className="h-4 w-4 text-muted-foreground" />
+            <span className="font-medium">기간:</span> {isSameDay ? start : `${start} ~ ${end}`}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <FileText className="h-4 w-4 text-muted-foreground" />
+            <span className="font-medium">사유:</span> {request.reason}
+          </div>
+        </div>
+
+        <div className="mt-6 flex justify-end">
+          <Button variant="outline" onClick={() => setModalOpen(false)}>
+            닫기
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default EmployeeVacationDetailModal;

--- a/src/Components/company/vacation/EmployeeVacationItem.tsx
+++ b/src/Components/company/vacation/EmployeeVacationItem.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from "react";
+import { TVacationRequest } from "@/model/types/vacation.type";
+import EmployeeVacationDetailModal from "@/components/common/modal/EmployeeVacationDetailModal";
+
+interface Props {
+  request: TVacationRequest;
+  icon: React.ReactNode;
+  label: string;
+  textColor: string;
+  start: string;
+  end: string;
+  isSameDay: boolean;
+}
+
+const EmployeeVacationItem = ({
+  request,
+  icon,
+  label,
+  textColor,
+  start,
+  end,
+  isSameDay,
+}: Props) => {
+  const [modalOpen, setModalOpen] = useState<boolean>(false);
+
+  return (
+    <>
+      <div
+        key={request.requestId}
+        className="flex cursor-pointer items-center justify-between rounded-md px-4 py-2 text-sm shadow-md hover:bg-muted"
+        onClick={() => setModalOpen(true)}
+      >
+        <div className="flex flex-col">
+          <span className="font-medium text-foreground">
+            {request.vacationType} | {isSameDay ? start : `${start} ~ ${end}`}
+          </span>
+          <span className="text-xs text-muted-foreground">{request.reason}</span>
+        </div>
+        <div className={`flex items-center gap-1 text-xs font-semibold ${textColor}`}>
+          {icon}
+          {label}
+        </div>
+      </div>
+      <EmployeeVacationDetailModal
+        modalOpen={modalOpen}
+        setModalOpen={setModalOpen}
+        request={request}
+        start={start}
+        end={end}
+        isSameDay={isSameDay}
+        label={label}
+      />
+    </>
+  );
+};
+
+export default EmployeeVacationItem;

--- a/src/Components/company/vacation/EmployeeVacationList.tsx
+++ b/src/Components/company/vacation/EmployeeVacationList.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
+import { CheckCircle2, Clock, XCircle } from "lucide-react";
+import { TVacationRequest } from "@/model/types/vacation.type";
+import EmployeeVacationItem from "./EmployeeVacationItem";
+
+interface Props {
+  requests: TVacationRequest[];
+  paginated?: boolean;
+}
+
+const getStatusInfo = (status: TVacationRequest["status"]) => {
+  switch (status) {
+    case "승인":
+      return {
+        icon: <CheckCircle2 className="h-4 w-4 text-green-500" />,
+        label: "승인됨",
+        textColor: "text-green-600",
+      };
+    case "거절":
+      return {
+        icon: <XCircle className="h-4 w-4 text-red-500" />,
+        label: "거절됨",
+        textColor: "text-red-600",
+      };
+    case "대기중":
+    default:
+      return {
+        icon: <Clock className="h-4 w-4 text-yellow-500" />,
+        label: "대기중",
+        textColor: "text-yellow-600",
+      };
+  }
+};
+
+const EmployeeVacationList = ({ requests, paginated = false }: Props) => {
+  const list = paginated
+    ? requests
+    : [...requests]
+        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+        .slice(0, 3);
+
+  return (
+    <div className="mt-4 flex flex-col gap-3">
+      {list.length > 0 ? (
+        list.map(request => {
+          const { icon, label, textColor } = getStatusInfo(request.status);
+          const start = format(new Date(request.startDate), "M월 d일 (E)", { locale: ko });
+          const end = format(new Date(request.endDate), "M월 d일 (E)", { locale: ko });
+          const isSameDay = request.startDate === request.endDate;
+
+          return (
+            <EmployeeVacationItem
+              request={request}
+              textColor={textColor}
+              icon={icon}
+              label={label}
+              start={start}
+              end={end}
+              isSameDay={isSameDay}
+            />
+          );
+        })
+      ) : (
+        <div className="text-sm text-muted-foreground">휴가 요청 내역이 없습니다.</div>
+      )}
+    </div>
+  );
+};
+
+export default EmployeeVacationList;

--- a/src/Components/employee/EmployeeEtcPageTitle.tsx
+++ b/src/Components/employee/EmployeeEtcPageTitle.tsx
@@ -18,7 +18,7 @@ const EmployeeEtcPageTitle = ({ title, className }: IEmployeeEtcPageTitleProps) 
         size="icon"
         onClick={() => navigate(-1)}
         aria-label="뒤로 가기"
-        className="bg-white-bg text-muted-foreground hover:text-foreground dark:bg-dark-bg"
+        className="bg-white-bg text-muted-foreground hover:bg-white-bg hover:text-foreground dark:bg-dark-bg"
       >
         <ChevronLeft className="h-16 w-16" />
       </Button>

--- a/src/Components/employee/mainpageBox/VacationBox.tsx
+++ b/src/Components/employee/mainpageBox/VacationBox.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
 import { TVacationRequest } from "@/model/types/vacation.type";
+import EmployeeVacationList from "@/components/company/vacation/EmployeeVacationList";
 
 const VacationBox = () => {
   const navigate = useNavigate();
@@ -40,7 +41,7 @@ const VacationBox = () => {
       startDate: "2025-05-03",
       endDate: "2025-05-03",
       reason: "병원 진료",
-      status: "승인됨",
+      status: "승인",
       createdAt: "2025-03-29T12:00:00Z",
       processedAt: "2025-03-30T09:00:00Z",
     },
@@ -56,35 +57,11 @@ const VacationBox = () => {
       startDate: "2025-04-25",
       endDate: "2025-04-25",
       reason: "집안일",
-      status: "거절됨",
+      status: "거절",
       createdAt: "2025-03-27T11:00:00Z",
       processedAt: "2025-03-28T09:00:00Z",
     },
   ];
-
-  const getStatusInfo = (status: TVacationRequest["status"]) => {
-    switch (status) {
-      case "승인됨":
-        return {
-          icon: <CheckCircle2 className="h-4 w-4 text-green-500" />,
-          label: "승인됨",
-          textColor: "text-green-600",
-        };
-      case "거절됨":
-        return {
-          icon: <XCircle className="h-4 w-4 text-red-500" />,
-          label: "거절됨",
-          textColor: "text-red-600",
-        };
-      case "대기중":
-      default:
-        return {
-          icon: <Clock className="h-4 w-4 text-yellow-500" />,
-          label: "대기중",
-          textColor: "text-yellow-600",
-        };
-    }
-  };
 
   // 최신순 정렬 후 최대 3개
   const latestRequests = [...vacationRequests]
@@ -102,40 +79,11 @@ const VacationBox = () => {
       {/* 헤더 */}
       <div className="flex items-center gap-2 text-base font-semibold">
         <PlaneTakeoff className="h-5 w-5 text-primary" />
-        <CardTitle className="text-base">내 휴가 내역</CardTitle>
+        <CardTitle className="text-base">나의 휴가 내역</CardTitle>
       </div>
 
       {/* 휴가 요청 리스트 */}
-      <div className="mt-4 flex flex-col gap-3">
-        {latestRequests.length > 0 ? (
-          latestRequests.map(request => {
-            const { icon, label, textColor } = getStatusInfo(request.status);
-            const start = format(new Date(request.startDate), "M월 d일 (E)", { locale: ko });
-            const end = format(new Date(request.endDate), "M월 d일 (E)", { locale: ko });
-            const isSameDay = request.startDate === request.endDate;
-
-            return (
-              <div
-                key={request.requestId}
-                className="flex items-center justify-between rounded-md px-4 py-2 text-sm shadow-md"
-              >
-                <div className="flex flex-col">
-                  <span className="font-medium text-foreground">
-                    {request.vacationType} | {isSameDay ? start : `${start} ~ ${end}`}
-                  </span>
-                  <span className="text-xs text-muted-foreground">{request.reason}</span>
-                </div>
-                <div className={`flex items-center gap-1 text-xs font-semibold ${textColor}`}>
-                  {icon}
-                  {label}
-                </div>
-              </div>
-            );
-          })
-        ) : (
-          <div className="text-sm text-muted-foreground">휴가 요청 내역이 없습니다.</div>
-        )}
-      </div>
+      <EmployeeVacationList requests={vacationRequests} />
     </Card>
   );
 };

--- a/src/pages/employee/MyVacationPage.tsx
+++ b/src/pages/employee/MyVacationPage.tsx
@@ -3,23 +3,276 @@ import { IVacationRequest } from "@/components/company/table/VacationColumns";
 import { useMyVacation } from "@/hooks/employee/useMyVacation";
 import { useVacationRequests } from "@/hooks/manager/useVacationRequests";
 import VacationRequestModal from "@/components/common/modal/VacationRequestModal";
+import { Card, CardContent, CardTitle } from "@/components/ui/card";
+import { PlaneTakeoff, ChevronLeft, ChevronRight } from "lucide-react";
+import { useState } from "react";
+import EmployeeVacationList from "@/components/company/vacation/EmployeeVacationList";
+import { TVacationRequest } from "@/model/types/vacation.type";
+import Pagination from "@/components/ui/pagination";
+
+const vacationRequests: TVacationRequest[] = [
+  {
+    requestId: "1",
+    requester: {
+      uid: "u1",
+      name: "홍길동",
+      email: "hong@example.com",
+      jobName: "프론트엔드 개발자",
+    },
+    vacationType: "연차",
+    startDate: "2025-05-10",
+    endDate: "2025-05-10",
+    reason: "개인 사유",
+    status: "대기중",
+    createdAt: "2025-04-01T09:00:00Z",
+  },
+  {
+    requestId: "2",
+    requester: {
+      uid: "u1",
+      name: "홍길동",
+      email: "hong@example.com",
+      jobName: "프론트엔드 개발자",
+    },
+    vacationType: "반차",
+    startDate: "2025-05-03",
+    endDate: "2025-05-03",
+    reason: "병원 진료",
+    status: "승인",
+    createdAt: "2025-03-29T12:00:00Z",
+    processedAt: "2025-03-30T09:00:00Z",
+  },
+  {
+    requestId: "3",
+    requester: {
+      uid: "u1",
+      name: "홍길동",
+      email: "hong@example.com",
+      jobName: "프론트엔드 개발자",
+    },
+    vacationType: "연차",
+    startDate: "2025-04-25",
+    endDate: "2025-04-25",
+    reason: "집안일",
+    status: "거절",
+    createdAt: "2025-03-27T11:00:00Z",
+    processedAt: "2025-03-28T09:00:00Z",
+  },
+  {
+    requestId: "1",
+    requester: {
+      uid: "u1",
+      name: "홍길동",
+      email: "hong@example.com",
+      jobName: "프론트엔드 개발자",
+    },
+    vacationType: "연차",
+    startDate: "2025-05-10",
+    endDate: "2025-05-10",
+    reason: "개인 사유",
+    status: "대기중",
+    createdAt: "2025-04-01T09:00:00Z",
+  },
+  {
+    requestId: "2",
+    requester: {
+      uid: "u1",
+      name: "홍길동",
+      email: "hong@example.com",
+      jobName: "프론트엔드 개발자",
+    },
+    vacationType: "반차",
+    startDate: "2025-05-03",
+    endDate: "2025-05-03",
+    reason: "병원 진료",
+    status: "승인",
+    createdAt: "2025-03-29T12:00:00Z",
+    processedAt: "2025-03-30T09:00:00Z",
+  },
+  {
+    requestId: "3",
+    requester: {
+      uid: "u1",
+      name: "홍길동",
+      email: "hong@example.com",
+      jobName: "프론트엔드 개발자",
+    },
+    vacationType: "연차",
+    startDate: "2025-04-25",
+    endDate: "2025-04-25",
+    reason: "집안일",
+    status: "거절",
+    createdAt: "2025-03-27T11:00:00Z",
+    processedAt: "2025-03-28T09:00:00Z",
+  },
+  {
+    requestId: "1",
+    requester: {
+      uid: "u1",
+      name: "홍길동",
+      email: "hong@example.com",
+      jobName: "프론트엔드 개발자",
+    },
+    vacationType: "연차",
+    startDate: "2025-05-10",
+    endDate: "2025-05-10",
+    reason: "개인 사유",
+    status: "대기중",
+    createdAt: "2025-04-01T09:00:00Z",
+  },
+  {
+    requestId: "2",
+    requester: {
+      uid: "u1",
+      name: "홍길동",
+      email: "hong@example.com",
+      jobName: "프론트엔드 개발자",
+    },
+    vacationType: "반차",
+    startDate: "2025-05-03",
+    endDate: "2025-05-03",
+    reason: "병원 진료",
+    status: "승인",
+    createdAt: "2025-03-29T12:00:00Z",
+    processedAt: "2025-03-30T09:00:00Z",
+  },
+  {
+    requestId: "3",
+    requester: {
+      uid: "u1",
+      name: "홍길동",
+      email: "hong@example.com",
+      jobName: "프론트엔드 개발자",
+    },
+    vacationType: "연차",
+    startDate: "2025-04-25",
+    endDate: "2025-04-25",
+    reason: "집안일",
+    status: "거절",
+    createdAt: "2025-03-27T11:00:00Z",
+    processedAt: "2025-03-28T09:00:00Z",
+  },
+];
 
 const MyVacationPage = () => {
   const { isModalOpen, toggleModal } = useMyVacation();
   const { requests } = useVacationRequests();
   const { register: handleRequest } = requests;
+  const [date, setDate] = useState(new Date());
+  const [currentPage, setCurrentPage] = useState(0);
+
+  const [filterStatus, setFilterStatus] = useState<"전체" | "대기중" | "승인" | "거절">("전체");
+  const filteredRequests =
+    filterStatus === "전체"
+      ? vacationRequests
+      : vacationRequests.filter(request => request.status === filterStatus);
+
+  const ITEMS_PER_PAGE = 7;
+  const totalPageCount = Math.ceil(filteredRequests.length / ITEMS_PER_PAGE);
+  const paginatedRequests = filteredRequests.slice(
+    currentPage * ITEMS_PER_PAGE,
+    (currentPage + 1) * ITEMS_PER_PAGE,
+  );
 
   const handleSubmit = (data: IVacationRequest) => {
     handleRequest(data);
   };
 
+  const year = date.getFullYear();
+
+  const handleYearChange = (direction: "prev" | "next") => {
+    setDate(prev => {
+      const newDate = new Date(prev);
+      newDate.setFullYear(direction === "prev" ? prev.getFullYear() - 1 : prev.getFullYear() + 1);
+      return newDate;
+    });
+  };
+
   return (
-    <div className="p-3">
-      <div>
-        <Button className="w-full cursor-pointer" onClick={toggleModal}>
-          휴가 요청
-        </Button>
-      </div>
+    <div className="flex w-full flex-col gap-4 sm:py-5">
+      <Button className="w-full cursor-pointer" onClick={toggleModal}>
+        휴가 요청
+      </Button>
+
+      {/* 연도 선택 카드 */}
+      <Card className="bg-vacation-color dark:bg-vacation-color relative cursor-pointer rounded-xl p-4 text-white shadow-md transition">
+        <div className="flex items-center justify-center">
+          <div className="flex items-center gap-4">
+            <Button
+              onClick={() => handleYearChange("prev")}
+              size="icon"
+              className="h-7 w-7 bg-white/20 text-white hover:bg-white/30"
+              aria-label="이전 연도"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm font-medium">{year}년</span>
+            <Button
+              onClick={() => handleYearChange("next")}
+              size="icon"
+              className="h-7 w-7 bg-white/20 text-white hover:bg-white/30"
+              aria-label="다음 연도"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+
+        <CardContent className="mt-6 flex flex-col items-center justify-center gap-6 p-0 text-sm text-white">
+          <div className="flex items-center gap-2">
+            <span className="text-base">
+              {year}년에 사용한 휴가는 총 <span className="font-bold underline">0일</span>입니다.
+            </span>
+          </div>
+
+          {/* 휴가 상세 수치 정보 - 뱃지 형식 */}
+          <div className="flex flex-wrap items-center justify-center gap-2 text-xs text-white/80">
+            <span className="rounded-full bg-white/10 px-2 py-1">연차 휴가 10일</span>
+            <span className="rounded-full bg-white/10 px-2 py-1">반차 휴가 11일</span>
+            <span className="rounded-full bg-white/10 px-2 py-1">특별 휴가 12일</span>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* 나의 휴가 내역 카드 */}
+      <Card className="relative flex cursor-pointer flex-col gap-5 p-4 shadow-md transition hover:bg-gray-50 dark:hover:bg-dark-card-bg">
+        <div className="flex items-center gap-2 text-base font-semibold">
+          <PlaneTakeoff className="h-5 w-5 text-primary" />
+          <CardTitle className="text-base">나의 휴가 내역</CardTitle>
+        </div>
+
+        {/* 필터 버튼 */}
+        <div className="flex gap-2 text-sm font-medium">
+          {["전체", "대기중", "승인", "거절"].map(status => (
+            <Button
+              key={status}
+              size="sm"
+              variant={filterStatus === status ? "default" : "outline"}
+              onClick={() => {
+                setFilterStatus(status as any);
+                setCurrentPage(0);
+              }}
+            >
+              {status}
+            </Button>
+          ))}
+        </div>
+
+        {/* 리스트 */}
+        <EmployeeVacationList
+          key={`${filterStatus}-${currentPage}`}
+          requests={paginatedRequests}
+          paginated
+        />
+
+        {/* 페이지네이션 */}
+        <Pagination
+          page={currentPage}
+          totalPageCount={totalPageCount}
+          onNext={() => setCurrentPage(prev => Math.min(prev + 1, totalPageCount - 1))}
+          onPrevious={() => setCurrentPage(prev => Math.max(prev - 1, 0))}
+        />
+      </Card>
 
       {isModalOpen && <VacationRequestModal onClose={toggleModal} onRegister={handleSubmit} />}
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,117 +5,115 @@ export default {
   },
   content: ["./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-  	extend: {
-  		colors: {
-  			'point-color': '#FFD369',
-  			'dark-bg': '#09090B',
-  			'dark-card-bg': '#202020',
-  			'dark-text': '#FFFFFF',
-  			'dark-border': '#FFFFFF80',
-  			'dark-border-sub': '#FFFFFF33',
-  			'dark-nav-text': '#909090',
-  			'dark-nav-selected': '#FFFFFF',
-  			'white-bg': '#EEEEEE',
-  			'white-card-bg': '#FFFFFF',
-  			'white-text': '#000000',
-  			'white-border': '#00000080',
-  			'white-border-sub': '#00000033',
-  			'white-nav-text': '#6F6F6F',
-  			'white-nav-selected': '#000000',
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
-  			card: {
-  				DEFAULT: 'hsl(var(--card))',
-  				foreground: 'hsl(var(--card-foreground))'
-  			},
-  			popover: {
-  				DEFAULT: 'hsl(var(--popover))',
-  				foreground: 'hsl(var(--popover-foreground))'
-  			},
-  			primary: {
-  				DEFAULT: 'hsl(var(--primary))',
-  				foreground: 'hsl(var(--primary-foreground))'
-  			},
-  			secondary: {
-  				DEFAULT: 'hsl(var(--secondary))',
-  				foreground: 'hsl(var(--secondary-foreground))'
-  			},
-  			muted: {
-  				DEFAULT: 'hsl(var(--muted))',
-  				foreground: 'hsl(var(--muted-foreground))'
-  			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
-  			border: 'hsl(var(--border))',
-  			input: 'hsl(var(--input))',
-  			ring: 'hsl(var(--ring))',
-  			chart: {
-  				'1': 'hsl(var(--chart-1))',
-  				'2': 'hsl(var(--chart-2))',
-  				'3': 'hsl(var(--chart-3))',
-  				'4': 'hsl(var(--chart-4))',
-  				'5': 'hsl(var(--chart-5))'
-  			},
-  			sidebar: {
-  				DEFAULT: 'hsl(var(--sidebar-background))',
-  				foreground: 'hsl(var(--sidebar-foreground))',
-  				primary: 'hsl(var(--sidebar-primary))',
-  				'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
-  				accent: 'hsl(var(--sidebar-accent))',
-  				'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
-  				border: 'hsl(var(--sidebar-border))',
-  				ring: 'hsl(var(--sidebar-ring))'
-  			}
-  		},
-  		fontFamily: {
-  			baseFont: [
-  				'Montserrat',
-  				'sans-serif'
-  			]
-  		},
-  		keyframes: {
-  			underline: {
-  				from: {
-  					width: '0%'
-  				},
-  				to: {
-  					width: '100%'
-  				}
-  			},
-  			'accordion-down': {
-  				from: {
-  					height: '0'
-  				},
-  				to: {
-  					height: 'var(--radix-accordion-content-height)'
-  				}
-  			},
-  			'accordion-up': {
-  				from: {
-  					height: 'var(--radix-accordion-content-height)'
-  				},
-  				to: {
-  					height: '0'
-  				}
-  			}
-  		},
-  		animation: {
-  			underline: 'underline 0.5s ease-in-out forwards',
-  			'accordion-down': 'accordion-down 0.2s ease-out',
-  			'accordion-up': 'accordion-up 0.2s ease-out'
-  		},
-  		borderRadius: {
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
-  		}
-  	}
+    extend: {
+      colors: {
+        "point-color": "#FFD369",
+        "vacation-color": "#609966",
+        "dark-bg": "#09090B",
+        "dark-card-bg": "#202020",
+        "dark-text": "#FFFFFF",
+        "dark-border": "#FFFFFF80",
+        "dark-border-sub": "#FFFFFF33",
+        "dark-nav-text": "#909090",
+        "dark-nav-selected": "#FFFFFF",
+        "white-bg": "#EEEEEE",
+        "white-card-bg": "#FFFFFF",
+        "white-text": "#000000",
+        "white-border": "#00000080",
+        "white-border-sub": "#00000033",
+        "white-nav-text": "#6F6F6F",
+        "white-nav-selected": "#000000",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        chart: {
+          1: "hsl(var(--chart-1))",
+          2: "hsl(var(--chart-2))",
+          3: "hsl(var(--chart-3))",
+          4: "hsl(var(--chart-4))",
+          5: "hsl(var(--chart-5))",
+        },
+        sidebar: {
+          DEFAULT: "hsl(var(--sidebar-background))",
+          foreground: "hsl(var(--sidebar-foreground))",
+          primary: "hsl(var(--sidebar-primary))",
+          "primary-foreground": "hsl(var(--sidebar-primary-foreground))",
+          accent: "hsl(var(--sidebar-accent))",
+          "accent-foreground": "hsl(var(--sidebar-accent-foreground))",
+          border: "hsl(var(--sidebar-border))",
+          ring: "hsl(var(--sidebar-ring))",
+        },
+      },
+      fontFamily: {
+        baseFont: ["Montserrat", "sans-serif"],
+      },
+      keyframes: {
+        underline: {
+          from: {
+            width: "0%",
+          },
+          to: {
+            width: "100%",
+          },
+        },
+        "accordion-down": {
+          from: {
+            height: "0",
+          },
+          to: {
+            height: "var(--radix-accordion-content-height)",
+          },
+        },
+        "accordion-up": {
+          from: {
+            height: "var(--radix-accordion-content-height)",
+          },
+          to: {
+            height: "0",
+          },
+        },
+      },
+      animation: {
+        underline: "underline 0.5s ease-in-out forwards",
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+    },
   },
   darkMode: ["class"],
   // eslint-disable-next-line no-undef


### PR DESCRIPTION
## #️⃣연관된 이슈

> #146 

## 📝작업 내용

> 직원 휴가 페이지 상세 ui 작업했습니당
![Screenshot 2025-04-02 at 9 08 26 PM](https://github.com/user-attachments/assets/37614f0f-f67a-4151-83a7-55c634747db1)

년별로 휴가 사용 일수 간단하게 보여주는 summary 부분과 필터를 통해서 나의 내역을 볼 수 있는 휴가 내역 ui 로 구상하였습니다.

또한, 페이지네이션으로 7개씩 잘라서 보여줄 예정입니다.

> 휴가 내역 상세 모달

![Screenshot 2025-04-02 at 9 09 54 PM](https://github.com/user-attachments/assets/66b64313-b093-4cfb-b1e6-e682b43c59b4)
휴가 상세 모달을 재사용하고 싶었는데 그건 후에 리팩부분에서 다룰 예정입니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> API 연동 이슈, 브랜치 통해서 연동과 함께 더미데이터 제거 및 리팩토링 예정에 있습니다.
