### PR TITLE
[#168] : 직원 홈페이지 이번주 출퇴근 현황 데이터 연동 및 UI 수정

### DIFF
--- a/src/Components/employee/mainpageBox/CommuteHistoryBox.tsx
+++ b/src/Components/employee/mainpageBox/CommuteHistoryBox.tsx
@@ -77,15 +77,6 @@ const CommuteHistoryBox = () => {
     fetchData();
   }, [companyCode]);
 
-  // 예시 데이터 (출근: true, 연차: false, undefined는 없음)
-  // const commuteData: Record<string, boolean | undefined> = {
-  //   [format(addDays(start, 0), "yyyy-MM-dd")]: true,
-  //   [format(addDays(start, 1), "yyyy-MM-dd")]: true,
-  //   [format(addDays(start, 2), "yyyy-MM-dd")]: false,
-  //   [format(addDays(start, 3), "yyyy-MM-dd")]: true,
-  //   [format(addDays(start, 4), "yyyy-MM-dd")]: true,
-  // };
-
   const renderStatusIcon = (date: Date) => {
     const key = format(date, "yyyy-MM-dd");
     const status = commuteData[key];

--- a/src/Components/employee/mainpageBox/CommuteHistoryBox.tsx
+++ b/src/Components/employee/mainpageBox/CommuteHistoryBox.tsx
@@ -1,9 +1,20 @@
 import { Card, CardTitle } from "@/components/ui/card";
 import { useNavigate, useParams } from "react-router-dom";
 import { CalendarCheck, CircleDot, CircleDashed, ChevronRight } from "lucide-react";
-import React from "react";
-import { addDays, startOfWeek, endOfWeek, format, isSameDay } from "date-fns";
+import { useEffect, useState } from "react";
+import {
+  addDays,
+  startOfWeek,
+  endOfWeek,
+  format,
+  isSameDay,
+  parseISO,
+  eachDayOfInterval,
+} from "date-fns";
 import { ko } from "date-fns/locale";
+import { fetchCommutesByPeriod } from "@/api/commute.api";
+import { useUserStore } from "@/store/user.store";
+import { fetchRegisteredVacationsByMonth } from "@/api/vacation.api";
 
 const CommuteHistoryBox = () => {
   const navigate = useNavigate();
@@ -14,22 +25,81 @@ const CommuteHistoryBox = () => {
   const end = endOfWeek(today, { weekStartsOn: 1 }); // 일요일
   const weekDates = Array.from({ length: 7 }, (_, i) => addDays(start, i));
 
+  type CommuteStatus = "출근" | "외근" | "휴가" | "기록없음";
+  const [commuteData, setCommuteData] = useState<Record<string, CommuteStatus>>({});
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const user = useUserStore.getState().currentUser;
+      const userId = user?.uid;
+      if (!companyCode || !userId) return;
+
+      const year = format(today, "yyyy");
+      const month = format(today, "MM");
+
+      const commuteDataRaw = await fetchCommutesByPeriod(companyCode, userId, year, month);
+      const vacationData = await fetchRegisteredVacationsByMonth(companyCode, year, month);
+
+      const myVacations = vacationData?.[userId] || {};
+
+      // 날짜 목록 생성 (예: "2025-04-23")
+      const vacationRanges = Object.values(myVacations).flatMap(v => {
+        const start = parseISO(v.startDate); // "2025-04-21"
+        const end = parseISO(v.endDate); // "2025-04-23"
+        return eachDayOfInterval({ start, end }).map(d => format(d, "yyyy-MM-dd"));
+      });
+
+      const weekData: Record<string, CommuteStatus> = {};
+
+      weekDates.forEach(date => {
+        const fullKey = format(date, "yyyy-MM-dd");
+        const dayKey = format(date, "d");
+        const commute = commuteDataRaw?.[dayKey];
+
+        if (vacationRanges.includes(fullKey)) {
+          weekData[fullKey] = "휴가";
+        } else if (commute) {
+          if (commute.outworkingMemo || commute.startWorkplaceId === "외근") {
+            weekData[fullKey] = "외근";
+          } else if (commute.startTime) {
+            weekData[fullKey] = "출근";
+          } else {
+            weekData[fullKey] = "기록없음";
+          }
+        } else {
+          weekData[fullKey] = "기록없음";
+        }
+      });
+
+      setCommuteData(weekData);
+    };
+
+    fetchData();
+  }, [companyCode]);
+
   // 예시 데이터 (출근: true, 연차: false, undefined는 없음)
-  const commuteData: Record<string, boolean | undefined> = {
-    [format(addDays(start, 0), "yyyy-MM-dd")]: true,
-    [format(addDays(start, 1), "yyyy-MM-dd")]: true,
-    [format(addDays(start, 2), "yyyy-MM-dd")]: false,
-    [format(addDays(start, 3), "yyyy-MM-dd")]: true,
-    [format(addDays(start, 4), "yyyy-MM-dd")]: true,
-  };
+  // const commuteData: Record<string, boolean | undefined> = {
+  //   [format(addDays(start, 0), "yyyy-MM-dd")]: true,
+  //   [format(addDays(start, 1), "yyyy-MM-dd")]: true,
+  //   [format(addDays(start, 2), "yyyy-MM-dd")]: false,
+  //   [format(addDays(start, 3), "yyyy-MM-dd")]: true,
+  //   [format(addDays(start, 4), "yyyy-MM-dd")]: true,
+  // };
 
   const renderStatusIcon = (date: Date) => {
     const key = format(date, "yyyy-MM-dd");
     const status = commuteData[key];
 
-    if (status === true) return <CircleDot className="h-4 w-4 text-green-500" />;
-    if (status === false) return <CircleDashed className="h-4 w-4 text-yellow-500" />;
-    return <CircleDot className="h-4 w-4 text-gray-400" />;
+    switch (status) {
+      case "출근":
+        return <CircleDot className="h-4 w-4 text-green-500" />;
+      case "휴가":
+        return <CircleDot className="h-4 w-4 text-blue-500" />;
+      case "외근":
+        return <CircleDot className="h-4 w-4 text-yellow-500" />;
+      default:
+        return <CircleDashed className="h-4 w-4 text-gray-400" />;
+    }
   };
 
   return (
@@ -63,17 +133,22 @@ const CommuteHistoryBox = () => {
       </div>
 
       {/* 범례 설명 */}
+      {/* 범례 설명 */}
       <div className="mt-10 flex flex-wrap gap-4 text-xs text-muted-foreground">
         <div className="flex items-center gap-1">
           <CircleDot className="h-3 w-3 text-green-500" />
           출근
         </div>
         <div className="flex items-center gap-1">
-          <CircleDashed className="h-3 w-3 text-yellow-500" />
+          <CircleDot className="h-3 w-3 text-blue-500" />
           휴가
         </div>
         <div className="flex items-center gap-1">
-          <CircleDot className="h-3 w-3 text-gray-400" />
+          <CircleDot className="h-3 w-3 text-yellow-500" />
+          외근
+        </div>
+        <div className="flex items-center gap-1">
+          <CircleDashed className="h-3 w-3 text-gray-400" />
           기록 없음
         </div>
       </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #168 

## 📝작업 내용
> 홈페이지 / 출퇴근기록 페이지 비교
- 그에 따른 UI 부분도 통일해서 수정하였습니다.
<img width="335" alt="스크린샷 2025-04-23 오후 11 25 15" src="https://github.com/user-attachments/assets/7f4a302a-0b1a-41a7-b119-220bae19ea8e" />
<img width="337" alt="스크린샷 2025-04-23 오후 11 25 58" src="https://github.com/user-attachments/assets/7d666b2f-75fb-49b0-8fc1-373476ddf601" />

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
