### PR TITLE
[#189] : notice qa

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,6 @@
         "recoil": "^0.7.7",
         "redux": "^4.2.1",
         "redux-devtools-extension": "^2.13.9",
-        "swiper": "^11.2.6",
         "tailwind-merge": "^3.0.1",
         "tailwindcss-animate": "^1.0.7",
         "uuid": "^9.0.1",
@@ -18430,25 +18429,6 @@
       "peer": true,
       "peerDependencies": {
         "react": ">=17.0"
-      }
-    },
-    "node_modules/swiper": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.6.tgz",
-      "integrity": "sha512-8aXpYKtjy3DjcbzZfz+/OX/GhcU5h+looA6PbAzHMZT6ESSycSp9nAjPCenczgJyslV+rUGse64LMGpWE3PX9Q==",
-      "funding": [
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
-        },
-        {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.7.0"
       }
     },
     "node_modules/tailwind-merge": {

--- a/src/Components/common/modal/NoticeModal.tsx
+++ b/src/Components/common/modal/NoticeModal.tsx
@@ -77,7 +77,7 @@ const NoticeModal = ({ onClose, onSave }: NoticeModalProps) => {
             placeholder="내용을 입력하세요"
             value={content}
             onChange={e => setContent(e.target.value)}
-            rows={6}
+            rows={10}
           />
         </div>
 

--- a/src/Components/common/modal/NoticeModal.tsx
+++ b/src/Components/common/modal/NoticeModal.tsx
@@ -6,19 +6,27 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { format } from "date-fns";
+import { TNoticeType } from "@/model/types/manager.type";
 
 interface NoticeModalProps {
   onClose: () => void;
-  onSave: (notice: { title: string; content: string; createdAt: string }) => void;
+  onSave: (notice: {
+    title: string;
+    content: string;
+    createdAt: string;
+    noticeType: TNoticeType;
+  }) => void;
 }
 
 const NoticeModal = ({ onClose, onSave }: NoticeModalProps) => {
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
+  const [noticeType, setNoticeType] = useState<TNoticeType>("일반");
 
   const handleSave = () => {
     if (!title.trim() || !content.trim()) return;
@@ -27,6 +35,7 @@ const NoticeModal = ({ onClose, onSave }: NoticeModalProps) => {
       title,
       content,
       createdAt: format(new Date(), "yyyy.MM.dd"),
+      noticeType,
     });
     setTitle("");
     setContent("");
@@ -34,12 +43,31 @@ const NoticeModal = ({ onClose, onSave }: NoticeModalProps) => {
 
   return (
     <Dialog open onOpenChange={onClose}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle>공지사항 작성</DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-4">
+        <div className="space-y-5">
+          <RadioGroup
+            value={noticeType}
+            onValueChange={val => setNoticeType(val as TNoticeType)}
+            className="mt-3 flex gap-2"
+          >
+            <div className="text-sm">공지 유형 :</div>
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="일반" id="general" />
+              <label htmlFor="general" className="text-sm">
+                일반
+              </label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="중요" id="important" />
+              <label htmlFor="important" className="text-sm">
+                중요
+              </label>
+            </div>
+          </RadioGroup>
           <Input
             placeholder="제목을 입력하세요"
             value={title}

--- a/src/Components/company/notice/NoticeCard.tsx
+++ b/src/Components/company/notice/NoticeCard.tsx
@@ -1,38 +1,56 @@
 import { useState } from "react";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { X } from "lucide-react";
 
 interface NoticeCardProps {
   title: string;
   content: string;
   createdAt: string;
+  onDelete?: () => void;
+  noticeType?: "중요" | "일반";
 }
 
-const NoticeCard = ({ title, content, createdAt }: NoticeCardProps) => {
+const NoticeCard = ({ title, content, createdAt, onDelete, noticeType }: NoticeCardProps) => {
   const [open, setOpen] = useState(false);
   return (
-    <div
-      className="cursor-pointer rounded-md border border-white-border bg-white-card-bg p-4 shadow-sm transition-all duration-200 dark:border-dark-border dark:bg-dark-card-bg"
-      onClick={() => setOpen(prev => !prev)}
-    >
-      <div className="flex items-start justify-between gap-2">
-        <div>
-          <h3 className="text-base font-semibold text-white-text dark:text-dark-text">{title}</h3>
-          <p
-            className={`mt-1 text-sm text-muted-foreground transition-all duration-200 ${
-              open ? "" : "line-clamp-1"
-            }`}
-          >
-            {content}
-          </p>
-        </div>
-        <div className="flex flex-col items-end whitespace-nowrap pt-1 text-xs text-muted-foreground">
-          <span>{createdAt}</span>
-          {content.length > 40 && (
-            <span className="mt-1 text-[10px] text-gray-400">
-              {open ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
-            </span>
+    <div className="self-start rounded-md border border-white-border bg-white-card-bg p-5 shadow-md transition-all duration-200 dark:border-dark-border dark:bg-dark-card-bg">
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-2">
+          {noticeType === "중요" && (
+            <span className="rounded text-sm font-semibold text-red-500">[중요]</span>
           )}
+          <h3 className="text-base font-semibold text-white-text dark:text-dark-text">{title}</h3>
         </div>
+
+        {onDelete && (
+          <button
+            onClick={onDelete}
+            className="text-muted-foreground hover:text-destructive"
+            aria-label="삭제"
+          >
+            <X size={18} />
+          </button>
+        )}
+      </div>
+
+      <div
+        className={`my-4 mr-10 cursor-pointer overflow-hidden text-sm text-muted-foreground transition-all duration-500 ease-in-out ${
+          open ? "max-h-[500px]" : "max-h-[24px]"
+        }`}
+        onClick={() => setOpen(prev => !prev)}
+      >
+        <p className={`${!open ? "line-clamp-1" : ""}`}>{content}</p>
+      </div>
+
+      <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
+        <span>{createdAt}</span>
+        {content.length > 40 && (
+          <button
+            onClick={() => setOpen(prev => !prev)}
+            className="text-[13px] underline underline-offset-2 hover:text-white-text dark:hover:text-dark-text"
+          >
+            {open ? "간략히" : "자세히"}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/Components/company/notice/NoticeCard.tsx
+++ b/src/Components/company/notice/NoticeCard.tsx
@@ -33,12 +33,17 @@ const NoticeCard = ({ title, content, createdAt, onDelete, noticeType }: NoticeC
       </div>
 
       <div
-        className={`my-4 mr-10 cursor-pointer overflow-hidden text-sm text-muted-foreground transition-all duration-500 ease-in-out ${
+        className={`my-4 cursor-pointer overflow-hidden text-sm text-muted-foreground transition-all duration-500 ease-in-out ${
           open ? "max-h-[500px]" : "max-h-[24px]"
         }`}
         onClick={() => setOpen(prev => !prev)}
       >
-        <p className={`${!open ? "line-clamp-1" : ""}`}>{content}</p>
+        <p
+          className={`${!open ? "line-clamp-1" : ""}`}
+          style={{ whiteSpace: "pre-line" }} //
+        >
+          {content}
+        </p>
       </div>
 
       <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">

--- a/src/api/notice.api.ts
+++ b/src/api/notice.api.ts
@@ -1,17 +1,28 @@
 import { db } from "@/api";
-import { ref, push, onValue } from "firebase/database";
+import { ref, push, onValue, remove } from "firebase/database";
 import { TNotice } from "@/model/types/manager.type";
 
+// 공지사항 등록
 export const postNotice = async (companyCode: string, notice: TNotice) => {
   const refPath = ref(db, `notices/${companyCode}`);
   await push(refPath, notice);
 };
 
+// 공지사항 실시간 조회
 export const listenNotices = (companyCode: string, callback: (notices: TNotice[]) => void) => {
   const refPath = ref(db, `notices/${companyCode}`);
   onValue(refPath, snapshot => {
     const raw = snapshot.val() || {};
-    const mapped = Object.values(raw) as TNotice[];
-    callback(mapped.reverse()); // 최신순 정렬
+    const mapped = Object.entries(raw).map(([id, data]) => ({
+      ...(data as TNotice),
+      id,
+    }));
+    callback(mapped.reverse());
   });
+};
+
+// 공지사항 삭제
+export const deleteNotice = async (companyCode: string, noticeId: string) => {
+  const noticeRef = ref(db, `notices/${companyCode}/${noticeId}`);
+  await remove(noticeRef);
 };

--- a/src/hooks/manager/useNotice.ts
+++ b/src/hooks/manager/useNotice.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { TNotice } from "@/model/types/manager.type";
-import { postNotice, listenNotices } from "@/api/notice.api";
+import { postNotice, listenNotices, deleteNotice } from "@/api/notice.api";
 import { fetchEmployees } from "@/api/employee.api";
 import { useUserStore } from "@/store/user.store";
 import { sendNotification } from "@/api/notification.api";
@@ -34,5 +34,10 @@ export const useNotice = () => {
     }
   };
 
-  return { notices, addNotice };
+  const deleteNoticeItem = async (noticeId: string) => {
+    if (!companyCode) return;
+    await deleteNotice(companyCode, noticeId);
+  };
+
+  return { notices, addNotice, deleteNotice: deleteNoticeItem };
 };

--- a/src/model/types/manager.type.ts
+++ b/src/model/types/manager.type.ts
@@ -1,6 +1,7 @@
 import { EMPLOYMENT_TYPE } from "@/constants/employmentType";
 
 export type TSalaryType = keyof typeof EMPLOYMENT_TYPE;
+export type TNoticeType = "중요" | "일반";
 
 export type TEmployee = {
   uid: string;
@@ -18,4 +19,6 @@ export type TNotice = {
   title: string;
   content: string;
   createdAt: string;
+  noticeType?: TNoticeType;
+  id?: string;
 };

--- a/src/pages/manager/NoticePage.tsx
+++ b/src/pages/manager/NoticePage.tsx
@@ -1,6 +1,4 @@
-
-import { useState } from "react";
-import EmployeeEtcPageTitle from "@/components/employee/EmployeeEtcPageTitle";
+import { useEffect, useState } from "react";
 import Seo from "@/components/Seo";
 import NoticeModal from "@/components/common/modal/NoticeModal";
 import NoticeCard from "@/components/company/notice/NoticeCard";
@@ -8,23 +6,76 @@ import { Button } from "@/components/ui/button";
 import { TNotice } from "@/model/types/manager.type";
 import { useNotice } from "@/hooks/manager/useNotice";
 import { useUserStore } from "@/store/user.store";
+import { deleteNotice } from "@/api/notice.api";
+import { ChevronUp, Megaphone } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
 
 const NoticePage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { notices, addNotice } = useNotice();
   const userType = useUserStore(state => state.currentUser?.userType);
+  const companyCode = useUserStore(state => state.currentUser?.companyCode);
+  const { toast } = useToast();
+
+  const [page, setPage] = useState(1);
+  const noticesPerPage = 6;
+
+  const sortedNotices = [...notices].sort((a, b) => {
+    if (a.noticeType === "중요" && b.noticeType !== "중요") return -1;
+    if (a.noticeType !== "중요" && b.noticeType === "중요") return 1;
+    return 0;
+  });
+
+  const visibleNotices = sortedNotices.slice(0, page * noticesPerPage);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollPosition = window.innerHeight + window.scrollY;
+      const bottom = document.body.offsetHeight - 100;
+
+      if (scrollPosition >= bottom && page * noticesPerPage < sortedNotices.length) {
+        setPage(prev => prev + 1);
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [page, sortedNotices.length]);
 
   const handleSaveNotice = async (newNotice: TNotice) => {
     await addNotice(newNotice);
     setIsModalOpen(false);
+
+    toast({
+      title: "공지사항 등록 완료",
+      description: "새로운 공지사항이 등록되었습니다.",
+    });
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!companyCode) return;
+
+    const isConfirmed = window.confirm("정말로 이 공지사항을 삭제하시겠습니까?");
+    if (!isConfirmed) return;
+
+    await deleteNotice(companyCode, id);
+
+    toast({
+      title: "공지사항 삭제 완료",
+      description: "선택한 공지사항이 삭제되었습니다.",
+    });
   };
 
   return (
     <>
       <Seo title="공지사항 | On & Off" description="On & Off에서 근태관리 서비스를 이용해보세요." />
-      <div className="flex w-full flex-col gap-4 sm:py-5">
-        <div className="flex items-center justify-between px-4 sm:px-6">
-          {/* <EmployeeEtcPageTitle /> */}
+      <div className="flex w-full flex-col gap-4 sm:py-2">
+        <div className="flex max-w-7xl items-center justify-between px-4 sm:px-6">
+          <div className="flex items-center justify-between gap-3">
+            <Megaphone className="mb-1 h-6 w-6 text-white-text dark:text-dark-text" />
+            <h2 className="text-lg font-bold text-white-text dark:text-dark-text">공지사항</h2>
+            <span className="text-sm text-muted-foreground">총 {notices.length}개</span>
+          </div>
           {userType === "manager" && (
             <Button onClick={() => setIsModalOpen(true)} className="text-sm font-semibold">
               작성
@@ -32,14 +83,30 @@ const NoticePage = () => {
           )}
         </div>
 
-        <div className="flex max-w-5xl flex-col gap-4 px-4 sm:px-6">
-          {notices.length === 0 ? (
+        <div className="grid w-full max-w-7xl grid-cols-1 gap-4 px-4 sm:px-6 md:grid-cols-2">
+          {sortedNotices.length === 0 ? (
             <p className="text-sm text-muted-foreground">등록된 공지사항이 없습니다.</p>
           ) : (
-            notices.map((notice, idx) => <NoticeCard key={idx} {...notice} />)
+            sortedNotices.map((notice, idx) =>
+              notice.id ? (
+                <NoticeCard key={notice.id} {...notice} onDelete={() => handleDelete(notice.id!)} />
+              ) : null,
+            )
           )}
         </div>
       </div>
+
+      {visibleNotices.length > noticesPerPage && (
+        <div className="fixed bottom-8 right-8 z-50">
+          <button
+            onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+            className="dark:hover:bg-dark-hover flex h-10 w-10 items-center justify-center rounded-full bg-dark-bg shadow-md transition dark:bg-white-bg"
+            aria-label="맨 위로"
+          >
+            <ChevronUp className="h-7 w-7 text-dark-text dark:text-white-text" />
+          </button>
+        </div>
+      )}
 
       {isModalOpen && (
         <NoticeModal onClose={() => setIsModalOpen(false)} onSave={handleSaveNotice} />


### PR DESCRIPTION
## #️⃣연관된 이슈

> #189 

## 📝작업 내용

> 공지사항 QA
- 작성 버튼 오른쪽 이동 및 게시물 삭제 버튼 추가
- 페이지네이션 안할거면 페이지 스크롤 상단으로이동하는 버튼 구현
- 공지사항 개수 보여주는 걸로 여백 매꾸기 등등
- ++ 추가적으로 공지사항 게시물 유형 추가 (중요 공지 게시물은 최상단 고정)
- PC 전체화면으로 보면 생각보다 게시물의 공백이 너무 많아 1열에 두개 게시물을 배치해봤습니다. (모바일은 1열 1개입니다.)

![스크린샷 2025-05-06 오후 4 29 46](https://github.com/user-attachments/assets/9395e327-c682-4579-9a67-c8cdc88c8c48)
- 모달의 크기도 소폭 증가했습니다.
![스크린샷 2025-05-06 오후 4 30 05](https://github.com/user-attachments/assets/f81313c8-a967-49ee-86af-77ada7de7c37)

- 등록/삭제 확인 useToast 사용
- 삭제 시, 삭제 확인 문구 출력 (브라우저 알림)
![스크린샷 2025-05-06 오후 4 32 19](https://github.com/user-attachments/assets/5be64cd0-6996-407a-94b6-0c3eef820331)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 
