### PR TITLE
[#196] : 기타 회사 설정 QA 

### DIFF
--- a/src/Components/common/CompanySummaryInfo.tsx
+++ b/src/Components/common/CompanySummaryInfo.tsx
@@ -16,6 +16,7 @@ const CompanySummaryInfo = ({ type = "manager", className }: ICompanySummaryInfo
   const workType = useUserStore(state => state.currentUser?.employmentType);
   const companyName = useCompanyStore(state => state.currentCompany?.companyName);
   const companyLogo = useCompanyStore(state => state.currentCompany?.companyLogo);
+  const user = useUserStore(state => state.currentUser);
 
   return (
     <div

--- a/src/Components/common/PopoverHint.tsx
+++ b/src/Components/common/PopoverHint.tsx
@@ -1,0 +1,24 @@
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Info } from "lucide-react";
+
+interface PopoverHintProps {
+  contentText: string;
+  icon: React.ReactNode;
+}
+
+const PopoverHint = ({ contentText, icon }: PopoverHintProps) => {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button type="button" className="text-gray-500 hover:text-gray-700">
+          {icon}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent side="top" className="w-64 text-sm text-gray-700">
+        {contentText}
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default PopoverHint;

--- a/src/Components/common/modal/WorkPlaceModal.tsx
+++ b/src/Components/common/modal/WorkPlaceModal.tsx
@@ -50,7 +50,7 @@ const WorkPlaceModal = ({ isOpen, onClose, onSave }: WorkPlaceModalProps) => {
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="rounded-xl bg-white p-6 shadow-lg">
+      <DialogContent className="max-h-[90vh] w-full max-w-xs overflow-y-auto rounded-xl bg-white p-6 shadow-lg sm:max-h-[95vh] sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="mb-2 flex">
             <MapPin className="mr-2 h-4 w-4" />

--- a/src/Components/common/modal/WorkPlaceModal.tsx
+++ b/src/Components/common/modal/WorkPlaceModal.tsx
@@ -17,7 +17,7 @@ interface WorkPlaceModalProps {
   place?: TWorkPlace;
 }
 
-const WorkPlaceModal = ({ isOpen, onClose, onSave }: WorkPlaceModalProps) => {
+const WorkPlaceModal = ({ isOpen, onClose, onSave, place }: WorkPlaceModalProps) => {
   const {
     name,
     setName,
@@ -33,7 +33,7 @@ const WorkPlaceModal = ({ isOpen, onClose, onSave }: WorkPlaceModalProps) => {
     noResult,
     handleSearchAddress,
     handleSelectAddress,
-  } = useWorkPlaceModal();
+  } = useWorkPlaceModal(place);
 
   const [radius, setRadius] = useState(5);
   const radiusOptions = [1, 3, 5, 10, 20];

--- a/src/Components/common/modal/WorkPlaceModal.tsx
+++ b/src/Components/common/modal/WorkPlaceModal.tsx
@@ -50,7 +50,7 @@ const WorkPlaceModal = ({ isOpen, onClose, onSave, place }: WorkPlaceModalProps)
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-h-[90vh] w-full max-w-xs overflow-y-auto rounded-xl bg-white p-6 shadow-lg sm:max-h-[95vh] sm:max-w-md">
+      <DialogContent className="max-h-[90vh] w-full max-w-sm overflow-y-auto rounded-xl bg-white p-6 shadow-lg sm:max-h-[95vh] sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="mb-2 flex">
             <MapPin className="mr-2 h-4 w-4" />
@@ -62,7 +62,7 @@ const WorkPlaceModal = ({ isOpen, onClose, onSave, place }: WorkPlaceModalProps)
             <Label>근무지 이름</Label>
             <Input
               placeholder="예: 강남 본사"
-              className="h-12 placeholder:text-sm"
+              className="h-10 placeholder:text-sm"
               value={name}
               onChange={e => setName(e.target.value)}
             />
@@ -71,17 +71,17 @@ const WorkPlaceModal = ({ isOpen, onClose, onSave, place }: WorkPlaceModalProps)
             <Label>메모</Label>
             <Input
               placeholder="근무지에 대한 메모"
-              className="h-12 placeholder:text-sm"
+              className="h-10 placeholder:text-sm"
               value={memo}
               onChange={e => setMemo(e.target.value)}
             />
           </div>
           <div className="relative space-y-3">
             <Label>주소</Label>
-            <div className="flex h-12 items-center space-x-2">
+            <div className="flex h-10 items-center space-x-2">
               <Input
                 placeholder="도로명 주소를 입력하세요 (예: 기흥구 기흥로 116번길 10)"
-                className="h-12 placeholder:text-sm"
+                className="h-10 placeholder:text-xs sm:placeholder:text-sm"
                 value={address}
                 onChange={e => setAddress(e.target.value)}
                 onKeyDown={e => {
@@ -91,7 +91,7 @@ const WorkPlaceModal = ({ isOpen, onClose, onSave, place }: WorkPlaceModalProps)
                   }
                 }}
               />
-              <Button onClick={handleSearchAddress} disabled={isSearching} className="h-12">
+              <Button onClick={handleSearchAddress} disabled={isSearching} className="h-10">
                 <Search className="h-5 w-5" />
               </Button>
             </div>

--- a/src/Components/common/modal/WorkPlaceModal.tsx
+++ b/src/Components/common/modal/WorkPlaceModal.tsx
@@ -1,6 +1,6 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
-import { Search, MapPin } from "lucide-react";
+import { Search, MapPin, X } from "lucide-react";
 import { Button } from "../../ui/button";
 import { Input } from "@/components/ui/input";
 import { Slider } from "@/components/ui/slider";
@@ -52,11 +52,23 @@ const WorkPlaceModal = ({ isOpen, onClose, onSave, place }: WorkPlaceModalProps)
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-h-[90vh] w-full overflow-y-auto rounded-xl bg-white p-6 shadow-lg sm:max-h-[95vh] sm:max-w-md">
         <DialogHeader>
-          <DialogTitle className="mb-2 flex">
-            <MapPin className="mr-2 h-4 w-4" />
-            근무지 설정
-          </DialogTitle>
+          <div className="flex w-full items-center justify-between">
+            <div className="flex items-center">
+              <MapPin className="mr-2 h-4 w-4" />
+              <DialogTitle className="text-lg font-medium">근무지 설정</DialogTitle>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="text-muted-foreground hover:text-destructive"
+              onClick={onClose}
+            >
+              <X className="h-5 w-5" />
+            </Button>
+          </div>
         </DialogHeader>
+
         <div className="space-y-6">
           <div className="space-y-3">
             <Label>근무지 이름</Label>

--- a/src/Components/common/modal/WorkPlaceModal.tsx
+++ b/src/Components/common/modal/WorkPlaceModal.tsx
@@ -50,7 +50,7 @@ const WorkPlaceModal = ({ isOpen, onClose, onSave, place }: WorkPlaceModalProps)
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-h-[90vh] w-full max-w-sm overflow-y-auto rounded-xl bg-white p-6 shadow-lg sm:max-h-[95vh] sm:max-w-md">
+      <DialogContent className="max-h-[90vh] w-full overflow-y-auto rounded-xl bg-white p-6 shadow-lg sm:max-h-[95vh] sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="mb-2 flex">
             <MapPin className="mr-2 h-4 w-4" />

--- a/src/Components/company/company-settings/EmployeeInviteStep.tsx
+++ b/src/Components/company/company-settings/EmployeeInviteStep.tsx
@@ -23,32 +23,28 @@ const EmployeeInviteStep = () => {
   };
 
   return (
-    <div className="flex flex-col items-center space-y-6 w-full max-w-md">
+    <div className="flex w-full max-w-md flex-col items-center space-y-6">
       {/* 초대 코드 섹션 */}
-      <Card className="w-full ">
+      <Card className="w-full">
         <CardHeader className="text-center">
           <CardTitle className="text-lg font-semibold">직원 초대 코드</CardTitle>
-          <p className="text-gray-500 text-sm mt-1">
-            직원들은 아래 초대 코드를 사용하여 가입할 수 있습니다.
+          <p className="mt-1 text-sm text-gray-500">
+            직원들은 아래 초대 코드를 회원가입시 사용하여 가입할 수 있습니다.
           </p>
         </CardHeader>
         <CardContent className="flex flex-col items-center space-y-3">
-          <div className="flex items-center space-x-2 border border-gray-300 px-4 py-2 rounded-lg">
+          <div className="flex items-center space-x-2 rounded-lg border border-gray-300 px-4 py-2">
             <Input
-              className="w-40 text-lg font-bold text-center border-none"
+              className="w-40 border-none text-center text-lg font-bold"
               value={companyCode}
               readOnly
             />
             <Button variant="outline" size="icon" onClick={handleCopy} className="p-2">
-              <Copy className="w-5 h-5 text-gray-500" />
+              <Copy className="h-5 w-5 text-gray-500" />
             </Button>
           </div>
         </CardContent>
       </Card>
-      <NoticeCard
-        title="회사 QR"
-        description={<>회사 QR은 가입 후 다운받아 사용하실 수 있습니다.</>}
-      />
     </div>
   );
 };

--- a/src/Components/company/company-settings/job-setting/JobCard.tsx
+++ b/src/Components/company/company-settings/job-setting/JobCard.tsx
@@ -10,7 +10,7 @@ interface JobCardProps {
 
 const JobCard = ({ job, onRemove }: JobCardProps) => {
   return (
-    <Card className="flex items-center justify-between p-3">
+    <Card className="flex items-center justify-between p-4">
       <span className="text-sm font-medium">{job.name}</span>
       <Button
         type="button"

--- a/src/Components/company/company-settings/job-setting/JobListCard.tsx
+++ b/src/Components/company/company-settings/job-setting/JobListCard.tsx
@@ -16,11 +16,13 @@ const JobListCard = ({ jobs, onRemove }: JobListCardProps) => {
       <CardHeader>
         <CardTitle className="text-lg">추가된 직무 목록</CardTitle>
       </CardHeader>
-      <ScrollArea className="max-h-52 space-y-2 overflow-y-auto">
-        {jobs.map((job, index) => (
-          <JobCard key={job.id} job={job} onRemove={() => onRemove(index)} />
-        ))}
-      </ScrollArea>
+      <CardContent className="px-6">
+        <ScrollArea className="max-h-72 overflow-y-auto rounded-lg border border-solid border-white-border-sub dark:border-dark-border">
+          {jobs.map((job, index) => (
+            <JobCard key={job.id} job={job} onRemove={() => onRemove(index)} />
+          ))}
+        </ScrollArea>
+      </CardContent>
     </Card>
   );
 };

--- a/src/Components/company/company-settings/night-holiday-setting/HolidaySettings.tsx
+++ b/src/Components/company/company-settings/night-holiday-setting/HolidaySettings.tsx
@@ -89,6 +89,7 @@ const HolidaySettings = ({ type = "firstpage" }: IHolidaySettingsProps) => {
             <div className="text-sm text-white-text dark:text-dark-nav-text">
               회사 지정 공휴일 추가
             </div>
+
             <Popover>
               <PopoverTrigger asChild>
                 <Button className="bg-point-color text-black hover:bg-point-color hover:bg-opacity-80">

--- a/src/Components/company/company-settings/night-holiday-setting/HolidaySettings.tsx
+++ b/src/Components/company/company-settings/night-holiday-setting/HolidaySettings.tsx
@@ -7,10 +7,11 @@ import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { format } from "date-fns";
 import { Badge } from "@/components/ui/badge";
-import { HelpCircle, X } from "lucide-react";
+import { HelpCircle, Info, X } from "lucide-react";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { Input } from "@/components/ui/input";
 import TooltipContainer from "@/components/common/TooltipContainer";
+import PopoverHint from "@/components/common/PopoverHint";
 
 interface IHolidaySettingsProps {
   type?: "setting" | "firstpage";
@@ -50,8 +51,8 @@ const HolidaySettings = ({ type = "firstpage" }: IHolidaySettingsProps) => {
         <div className="flex w-full items-center justify-between">
           <CardTitle className="flex items-center gap-1 text-lg">
             공휴일/주말 추가 급여 적용
-            <TooltipContainer
-              icon={<HelpCircle size={16} />}
+            <PopoverHint
+              icon={<Info size={18} />}
               contentText="토, 일 및 국가 지정 공휴일에 적용됩니다."
             />
           </CardTitle>
@@ -105,14 +106,14 @@ const HolidaySettings = ({ type = "firstpage" }: IHolidaySettingsProps) => {
             </Popover>
             <div className="flex flex-wrap gap-2">
               {holidays.map((holiday: string, index: number) => (
-                <Badge key={index} className="flex items-center space-x-2 px-3 py-1">
-                  <span>{holiday}</span>
+                <Badge key={index} className="flex items-center gap-1 px-3 py-1">
+                  <span className="text-sm leading-tight">{holiday}</span>
                   <Button
                     type="button"
                     onClick={() => handleRemoveHoliday(holiday)}
-                    className="h-auto border-none bg-transparent p-0"
+                    className="h-4 w-4 bg-transparent p-0 pb-1 hover:text-red-400"
                   >
-                    <X className="h-4 w-4 text-white outline-none hover:text-red-300 dark:text-dark-bg" />
+                    <X className="h-4 w-4 text-white dark:text-dark-bg" />
                   </Button>
                 </Badge>
               ))}

--- a/src/Components/company/company-settings/workplace-setting/CompanyWorkPlaceStep.tsx
+++ b/src/Components/company/company-settings/workplace-setting/CompanyWorkPlaceStep.tsx
@@ -13,18 +13,27 @@ interface ICompanyWorkPlaceStepProps {
 const CompanyWorkPlaceStep = ({ type = "firstpage" }: ICompanyWorkPlaceStepProps) => {
   const { control } = useFormContext();
   const prefix = type === "firstpage" ? "companyWorkPlacesList." : "";
-  const { fields, append, remove } = useFieldArray({
+  const { fields, append, remove, update } = useFieldArray({
     control,
     name: `${prefix}companyWorkPlaces`,
   });
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingPlace, setEditingPlace] = useState<TWorkPlace | undefined>(undefined);
 
   const handleSaveWorkPlace = (workPlace: Omit<TWorkPlace, "id">) => {
-    append({
-      id: String(Date.now()),
-      ...workPlace,
-    });
+    if (editingPlace) {
+      const index = fields.findIndex(f => f.id === editingPlace.id);
+      if (index !== -1) {
+        update(index, { id: editingPlace.id, ...workPlace });
+      }
+    } else {
+      append({
+        id: String(Date.now()),
+        ...workPlace,
+      });
+    }
     setIsModalOpen(false);
+    setEditingPlace(undefined);
   };
 
   return (
@@ -36,11 +45,23 @@ const CompanyWorkPlaceStep = ({ type = "firstpage" }: ICompanyWorkPlaceStepProps
       <Button type="button" onClick={() => setIsModalOpen(true)}>
         근무지 추가
       </Button>
-      <WorkPlaceList workPlaces={fields as TworkPlacesList} onRemove={remove} />
+      <WorkPlaceList
+        workPlaces={fields as TworkPlacesList}
+        onRemove={remove}
+        onEdit={place => {
+          setEditingPlace(place);
+          setIsModalOpen(true);
+        }}
+      />
+
       <WorkPlaceModal
         isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
+        onClose={() => {
+          setIsModalOpen(false);
+          setEditingPlace(undefined);
+        }}
         onSave={handleSaveWorkPlace}
+        place={editingPlace}
       />
     </div>
   );

--- a/src/Components/company/company-settings/workplace-setting/SearchResults.tsx
+++ b/src/Components/company/company-settings/workplace-setting/SearchResults.tsx
@@ -8,13 +8,13 @@ interface SearchResultsProps {
 
 const SearchResults = ({ searchResults, noResult, onSelect }: SearchResultsProps) => {
   return (
-    <div className="absolute top-full left-0 w-full border rounded-md bg-white shadow-md max-h-40 overflow-y-auto mt-1 z-50">
+    <div className="absolute left-0 top-full z-50 mt-1 max-h-40 w-full overflow-y-auto rounded-md border bg-white shadow-md">
       {searchResults.length > 0 ? (
         searchResults.map((result, index) => (
           <SearchResultItem key={index} result={result} onSelect={onSelect} />
         ))
       ) : noResult ? (
-        <div className="p-2 text-center text-gray-500 text-sm">검색 결과가 없습니다.</div>
+        <div className="p-2 text-center text-sm text-gray-500">검색 결과가 없습니다.</div>
       ) : null}
     </div>
   );

--- a/src/Components/company/company-settings/workplace-setting/WorkPlaceItem.tsx
+++ b/src/Components/company/company-settings/workplace-setting/WorkPlaceItem.tsx
@@ -6,11 +6,15 @@ import { TWorkPlace } from "@/model/types/company.type";
 interface WorkPlaceItemProps {
   place: TWorkPlace;
   onRemove?: () => void;
+  onEdit?: (place: TWorkPlace) => void;
 }
 
-const WorkPlaceItem = ({ place, onRemove }: WorkPlaceItemProps) => {
+const WorkPlaceItem = ({ place, onRemove, onEdit }: WorkPlaceItemProps) => {
   return (
-    <Card className="flex items-center justify-between p-3">
+    <Card
+      className="flex cursor-pointer items-center justify-between p-3 transition-colors hover:bg-muted dark:hover:bg-muted"
+      onClick={() => onEdit?.(place)}
+    >
       <div className="flex items-center space-x-3">
         <MapPin className="h-5 w-5 text-gray-500" />
         <div>
@@ -31,7 +35,10 @@ const WorkPlaceItem = ({ place, onRemove }: WorkPlaceItemProps) => {
         <Button
           type="button"
           variant="outline"
-          onClick={onRemove}
+          onClick={e => {
+            e.stopPropagation();
+            onRemove();
+          }}
           className="h-auto bg-transparent p-0 hover:bg-transparent hover:text-red-500"
         >
           <X className="h-5 w-5" />

--- a/src/Components/company/company-settings/workplace-setting/WorkPlaceItem.tsx
+++ b/src/Components/company/company-settings/workplace-setting/WorkPlaceItem.tsx
@@ -12,7 +12,7 @@ interface WorkPlaceItemProps {
 const WorkPlaceItem = ({ place, onRemove, onEdit }: WorkPlaceItemProps) => {
   return (
     <Card
-      className="flex cursor-pointer items-center justify-between p-3 transition-colors hover:bg-muted dark:hover:bg-muted"
+      className="flex cursor-pointer items-center justify-between rounded-none p-3 transition-colors hover:bg-muted dark:hover:bg-muted"
       onClick={() => onEdit?.(place)}
     >
       <div className="flex items-center space-x-3">

--- a/src/Components/company/company-settings/workplace-setting/WorkPlaceList.tsx
+++ b/src/Components/company/company-settings/workplace-setting/WorkPlaceList.tsx
@@ -1,18 +1,20 @@
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { TworkPlacesList } from "@/model/types/company.type";
+import { TWorkPlace, TworkPlacesList } from "@/model/types/company.type";
 import WorkPlaceItem from "./WorkPlaceItem";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 interface WorkPlaceListProps {
   workPlaces: TworkPlacesList;
   onRemove: (index: number) => void;
+  onEdit?: (place: TWorkPlace) => void;
 }
 
-const WorkPlaceList = ({ workPlaces, onRemove }: WorkPlaceListProps) => {
+const WorkPlaceList = ({ workPlaces, onRemove, onEdit }: WorkPlaceListProps) => {
   return (
     <Card className="mt-4 w-full">
       <CardHeader>
         <CardTitle className="text-lg">추가된 근무지</CardTitle>
+        <p className="text-xs">*근무지 선택 시, 수정이 가능합니다.</p>
       </CardHeader>
       <CardContent className="px-6">
         {workPlaces.length === 0 ? (
@@ -22,7 +24,12 @@ const WorkPlaceList = ({ workPlaces, onRemove }: WorkPlaceListProps) => {
         ) : (
           <ScrollArea className="max-h-72 overflow-y-auto rounded-sm border border-solid border-white-border-sub dark:border-dark-border">
             {workPlaces.map((place, index) => (
-              <WorkPlaceItem key={place.id} place={place} onRemove={() => onRemove(index)} />
+              <WorkPlaceItem
+                key={place.id}
+                place={place}
+                onRemove={() => onRemove(index)}
+                onEdit={onEdit} // ✅ 전달
+              />
             ))}
           </ScrollArea>
         )}

--- a/src/Components/company/company-settings/workplace-setting/WorkPlaceList.tsx
+++ b/src/Components/company/company-settings/workplace-setting/WorkPlaceList.tsx
@@ -9,18 +9,24 @@ interface WorkPlaceListProps {
 }
 
 const WorkPlaceList = ({ workPlaces, onRemove }: WorkPlaceListProps) => {
-  if (workPlaces.length === 0) return null;
-
   return (
     <Card className="mt-4 w-full">
       <CardHeader>
         <CardTitle className="text-lg">추가된 근무지</CardTitle>
       </CardHeader>
-      <ScrollArea className="max-h-72 space-y-2 overflow-y-auto">
-        {workPlaces.map((place, index) => (
-          <WorkPlaceItem key={place.id} place={place} onRemove={() => onRemove(index)} />
-        ))}
-      </ScrollArea>
+      <CardContent className="px-6">
+        {workPlaces.length === 0 ? (
+          <div className="rounded-sm border border-solid border-white-border-sub p-12 dark:border-dark-border">
+            <p className="text-center text-sm text-muted-foreground">추가된 근무지가 없습니다.</p>
+          </div>
+        ) : (
+          <ScrollArea className="max-h-72 overflow-y-auto rounded-sm border border-solid border-white-border-sub dark:border-dark-border">
+            {workPlaces.map((place, index) => (
+              <WorkPlaceItem key={place.id} place={place} onRemove={() => onRemove(index)} />
+            ))}
+          </ScrollArea>
+        )}
+      </CardContent>
     </Card>
   );
 };

--- a/src/Components/company/company-settings/workplace-setting/WorkPlaceList.tsx
+++ b/src/Components/company/company-settings/workplace-setting/WorkPlaceList.tsx
@@ -14,7 +14,7 @@ const WorkPlaceList = ({ workPlaces, onRemove, onEdit }: WorkPlaceListProps) => 
     <Card className="mt-4 w-full">
       <CardHeader>
         <CardTitle className="text-lg">추가된 근무지</CardTitle>
-        <p className="text-xs">*근무지 선택 시, 수정이 가능합니다.</p>
+        <p className="text-xs">*추가된 근무지 클릭 시, 수정이 가능합니다.</p>
       </CardHeader>
       <CardContent className="px-6">
         {workPlaces.length === 0 ? (
@@ -22,7 +22,7 @@ const WorkPlaceList = ({ workPlaces, onRemove, onEdit }: WorkPlaceListProps) => 
             <p className="text-center text-sm text-muted-foreground">추가된 근무지가 없습니다.</p>
           </div>
         ) : (
-          <ScrollArea className="max-h-72 overflow-y-auto rounded-sm border border-solid border-white-border-sub dark:border-dark-border">
+          <ScrollArea className="max-h-72 overflow-y-auto rounded-lg border border-solid border-white-border-sub dark:border-dark-border">
             {workPlaces.map((place, index) => (
               <WorkPlaceItem
                 key={place.id}

--- a/src/Components/company/company-settings/workplace-setting/map/WorkPlaceMap.tsx
+++ b/src/Components/company/company-settings/workplace-setting/map/WorkPlaceMap.tsx
@@ -22,16 +22,13 @@ const WorkPlaceMap = ({
 }: WorkPlaceMapProps) => {
   return (
     <Suspense fallback={<Skeleton className="h-48 w-full animate-pulse rounded-md" />}>
-      {isLoaded && lat && lng && radius ? (
-        <NaverMap
-          onLocationSelect={onLocationSelect}
-          selectedLocation={{ lat, lng }}
-          markerDragAble={markerDragAble}
-          radius={radius}
-        />
-      ) : (
-        <Skeleton className="h-48 w-full animate-pulse rounded-md" />
-      )}
+      <NaverMap
+        onLocationSelect={onLocationSelect}
+        selectedLocation={{ lat, lng }}
+        markerDragAble={markerDragAble}
+        radius={radius}
+        isLoaded={isLoaded}
+      />
     </Suspense>
   );
 };

--- a/src/Components/company/form/FormInputWithButton.tsx
+++ b/src/Components/company/form/FormInputWithButton.tsx
@@ -27,7 +27,7 @@ const FormInputWithButton = ({
         placeholder={placeholder}
         className="h-10 py-2"
       />
-      <Button type="button" className="h-10 px-4" onClick={onSubmit}>
+      <Button variant="outline" type="button" className="h-10 px-4" onClick={onSubmit}>
         {buttonText}
       </Button>
     </div>

--- a/src/Components/employee/EmployeeJobSelection.tsx
+++ b/src/Components/employee/EmployeeJobSelection.tsx
@@ -6,9 +6,9 @@ import {
   SelectItem,
 } from "@/components/ui/select";
 import { Label } from "@/components/ui/label";
-import TooltipContainer from "@/components/common/TooltipContainer";
 import { Info } from "lucide-react";
 import { TJob } from "@/model/types/company.type";
+import PopoverHint from "../common/PopoverHint";
 
 interface IEmployeeJobSelectionProps {
   jobList: TJob[];
@@ -19,13 +19,13 @@ interface IEmployeeJobSelectionProps {
 const EmployeeJobSelection = ({ jobList, selectJob, setSelectJob }: IEmployeeJobSelectionProps) => {
   return (
     <div>
-      <Label className="text-black text-lg mb-3 flex items-center">
-        회사 직종 선택
-        <TooltipContainer
+      <div className="mb-3 flex items-center gap-2">
+        <Label className="text-lg text-black">회사 직종 선택</Label>
+        <PopoverHint
           icon={<Info size={18} />}
           contentText="관리자에게 안내받지 않았다면 선택 안함을 체크해주세요"
         />
-      </Label>
+      </div>
       <Select onValueChange={setSelectJob} value={selectJob}>
         <SelectTrigger className="w-full">
           <SelectValue placeholder="직종을 선택하세요" />

--- a/src/Components/employee/EmployeementTypeSelection.tsx
+++ b/src/Components/employee/EmployeementTypeSelection.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label";
 import TooltipContainer from "@/components/common/TooltipContainer";
 import { Info } from "lucide-react";
 import { TEmploymentType } from "@/model/types/position.type";
+import PopoverHint from "../common/PopoverHint";
 
 interface IEmploymentTypeSelectionProps {
   employmentType: TEmploymentType | undefined;
@@ -23,13 +24,13 @@ const EmploymentTypeSelection = ({
 }: IEmploymentTypeSelectionProps) => {
   return (
     <div>
-      <Label className="text-black text-lg mb-3 flex items-center">
-        고용 형태 선택
-        <TooltipContainer
+      <div className="mb-3 flex items-center gap-2">
+        <Label className="text-lg text-black">고용 형태 선택</Label>
+        <PopoverHint
           icon={<Info size={18} />}
           contentText="관리자에게 안내받지 않았다면 선택 안함을 체크해주세요"
         />
-      </Label>
+      </div>
       <Select onValueChange={setEmploymentType} value={employmentType}>
         <SelectTrigger className="w-full">
           <SelectValue placeholder="고용 형태를 선택하세요" />

--- a/src/hooks/auth/useSettingEmployee.ts
+++ b/src/hooks/auth/useSettingEmployee.ts
@@ -5,6 +5,7 @@ import { useShallow } from "zustand/shallow";
 import { useUserStore } from "@/store/user.store";
 import { TEmploymentType } from "@/model/types/position.type";
 import { setEmployeeUser } from "@/api/auth.api";
+import { TEmpUserData } from "@/model/types/user.type";
 
 export const useSettingEmployee = () => {
   const { toast } = useToast();
@@ -21,6 +22,9 @@ export const useSettingEmployee = () => {
       phoneNumber: state.currentUser?.phoneNumber,
     })),
   );
+  const setUser = useUserStore(state => state.setUser);
+  const currentUser = useUserStore(state => state.currentUser);
+
   const handleGoMain = async () => {
     if (!selectJob) {
       toast({
@@ -60,7 +64,17 @@ export const useSettingEmployee = () => {
         userType: "employee",
       });
       setLoading(false);
-      navigate(`/${companyCode}/appguide`);
+      toast({
+        description: "On&Off 가입이 완료되었습니다.",
+      });
+      if (currentUser) {
+        setUser({
+          ...(currentUser as TEmpUserData),
+          jobName: selectJob,
+          employmentType,
+        });
+      }
+      navigate(`/${companyCode}/companymain`);
     } catch (e: any) {
       setLoading(false);
       toast({

--- a/src/hooks/company-settings/useWorkPlaceModal.ts
+++ b/src/hooks/company-settings/useWorkPlaceModal.ts
@@ -1,4 +1,6 @@
+// import { PlaceCard } from './../../Components/company/attendance/DaliyAttendanceUI';
 import { fetchAddressByNaver } from "@/api/map.api";
+import { TWorkPlace } from "@/model/types/company.type";
 import { useState, useEffect } from "react";
 
 export interface IWorkPlace {
@@ -9,7 +11,7 @@ export interface IWorkPlace {
   lng: number;
 }
 
-export const useWorkPlaceModal = () => {
+export const useWorkPlaceModal = (place?: TWorkPlace) => {
   const [name, setName] = useState("");
   const [memo, setMemo] = useState("");
   const [address, setAddress] = useState("");
@@ -79,6 +81,22 @@ export const useWorkPlaceModal = () => {
     setLng(selectedLng);
     setSearchResults([]);
   };
+
+  useEffect(() => {
+    if (place) {
+      setName(place.name);
+      setMemo(place.memo);
+      setAddress(place.address);
+      setLat(place.lat);
+      setLng(place.lng);
+    } else {
+      setName("");
+      setMemo("");
+      setAddress("");
+      setLat(37.5665); // 기본값
+      setLng(126.978);
+    }
+  }, [place]);
 
   return {
     name,

--- a/src/pages/auth/signupProcessPage/EmployeeFirstPage.tsx
+++ b/src/pages/auth/signupProcessPage/EmployeeFirstPage.tsx
@@ -11,6 +11,7 @@ import CompanyInfo from "@/components/common/CompanyInfo";
 import AppTitle from "@/components/common/AppTitle";
 import EmployeeJobSelection from "@/components/employee/EmployeeJobSelection";
 import EmploymentTypeSelection from "@/components/employee/EmployeementTypeSelection";
+import { Label } from "@/components/ui/label";
 
 export default function EmployeeFirstPage() {
   const {
@@ -36,8 +37,8 @@ export default function EmployeeFirstPage() {
   if (loading) return <Loading />;
 
   return (
-    <div className="w-full min-h-screen flex flex-col items-center justify-center p-4 sm:p-6 bg-gray-50">
-      <div className="flex flex-col gap-6 w-full max-w-md sm:max-w-sm flex-1">
+    <div className="flex min-h-screen w-full flex-col items-center justify-center bg-gray-50 p-4 sm:p-6">
+      <div className="flex w-full max-w-md flex-1 flex-col gap-6 sm:max-w-sm">
         {/* Title */}
         <AppTitle />
         <CompanyInfo
@@ -46,7 +47,8 @@ export default function EmployeeFirstPage() {
           companyIntro={companyIntro}
         />
         {/* Job Selection Section */}
-        <Card className="p-6 rounded-xl bg-white flex flex-col space-y-6 shadow-md flex-1 mb-10">
+        <Card className="mb-10 flex flex-1 flex-col space-y-6 rounded-xl bg-white p-6 shadow-md">
+          <Label className="text-lg text-black">가입 정보</Label>
           {/* 사용자 정보 */}
           <UserInfoTable
             className="my-4"
@@ -69,12 +71,8 @@ export default function EmployeeFirstPage() {
           />
         </Card>
       </div>
-      <div className="w-full max-w-md sm-max-w-sm pb-6">
-        <Button
-          onClick={handleGoMain}
-          className="w-full py-3 text-lg font-semibold"
-          variant="secondary"
-        >
+      <div className="sm-max-w-sm w-full max-w-md pb-6">
+        <Button onClick={handleGoMain} className="w-full py-3 text-lg font-semibold">
           가입 완료
         </Button>
       </div>

--- a/src/pages/manager/CompanyInfoPage.tsx
+++ b/src/pages/manager/CompanyInfoPage.tsx
@@ -18,7 +18,7 @@ const CompanyInfoPage = () => {
         <FormProvider {...companyBasicForm}>
           <form
             onSubmit={handleSubmit(onSubmit, onInvalid)}
-            className="flex h-full flex-col items-center justify-center space-y-12 px-4"
+            className="flex h-full flex-col items-center justify-center space-y-12 px-4 py-10"
           >
             <CompanyBasicStep type="setting" />
             <Button type="submit">저장</Button>

--- a/src/pages/manager/WorkplaceManagePage.tsx
+++ b/src/pages/manager/WorkplaceManagePage.tsx
@@ -3,7 +3,6 @@ import CompanySettingPageContainer from "@/components/container/manager/CompanyS
 import Seo from "@/components/Seo";
 import { Button } from "@/components/ui/button";
 import { useWorkplacePage } from "@/hooks/company-settings/useWorkplacePage";
-import { useCompanyStore } from "@/store/company.store";
 import { FormProvider } from "react-hook-form";
 
 const WorkplaceManagePage = () => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #196
## 📝작업 내용

> 기타 회사 설정 관련 QA 
- 직무 관리 UI → 직무 리스트 테두리 추가

- 추가 직무 텍스트와 리스트 정렬

- 회사 기본설정 py 필요 작은화면에서 잘림

- 저장버튼 말고 추가버튼을 outline 등으로 덜 강조되도록 UI 변경

- 공휴일 설정 툴팁 hover 시 보이는게 조금 직관적이지 않음

- 근무지 설정 관련 부분에서 텍스트, border radius 일부 수정했습니다.



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- `useBlocker` 사용으로 미저장시 페이지 저장을 막기위한 기능 구현 위해서 기존 browserRouter -> createBrowerRouter 로 변경해야해서 조금 큰 작업이 될 것 같아서 이슈 따로 파서 #198 이슈 구현하도록 하겠습니다
