### PR TITLE
[#200] : vacation qa

### DIFF
--- a/src/Components/common/AutoCompleteInput.tsx
+++ b/src/Components/common/AutoCompleteInput.tsx
@@ -56,25 +56,26 @@ const AutoCompleteUserInput = ({
   };
 
   return (
-    <div className="relative w-full px-0.5">
+    <div className="relative w-full max-w-xs sm:max-w-md">
       <Input
         value={inputValue}
         onChange={handleChange}
         placeholder="이름 검색"
-        className="h-full rounded-sm pr-10 placeholder:text-sm"
+        className="h-10 w-full min-w-0 rounded-sm pr-10 placeholder:text-sm"
       />
       {inputValue && (
-        <button
-          type="button"
-          onClick={handleClearClick}
-          title="검색 초기화"
-          className="absolute right-2 top-1/2 -translate-y-1/2 border-none bg-transparent text-gray-400 hover:text-gray-600"
-        >
-          <XIcon size={16} />
-        </button>
+        <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
+          <button
+            type="button"
+            onClick={handleClearClick}
+            className="pointer-events-auto border-none bg-transparent text-gray-400 hover:text-gray-600"
+          >
+            <XIcon size={16} />
+          </button>
+        </div>
       )}
       {showSuggestions && filteredUsers.length > 0 && (
-        <ul className="absolute left-0 right-0 z-10 mt-2 max-h-72 w-full max-w-[calc(100vw-2rem)] overflow-y-auto rounded-lg border border-gray-200 bg-white p-2 shadow-lg">
+        <ul className="absolute left-0 z-10 mt-2 max-h-72 w-full max-w-xs overflow-y-auto rounded-lg border border-gray-200 bg-white p-2 shadow-lg sm:max-w-md">
           {filteredUsers.map((user, idx) => (
             <li
               key={idx}

--- a/src/Components/common/AutoCompleteInput.tsx
+++ b/src/Components/common/AutoCompleteInput.tsx
@@ -61,7 +61,7 @@ const AutoCompleteUserInput = ({
         value={inputValue}
         onChange={handleChange}
         placeholder="이름 검색"
-        className="h-10 w-full min-w-0 rounded-sm pr-10 placeholder:text-sm"
+        className="h-10 w-full min-w-0 rounded-sm pr-10 placeholder:text-sm dark:text-white-text"
       />
       {inputValue && (
         <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">

--- a/src/Components/common/modal/VacationDetailModal.tsx
+++ b/src/Components/common/modal/VacationDetailModal.tsx
@@ -1,15 +1,8 @@
-import React from "react";
+import { PlaneTakeoff, User, BadgeCheck, Calendar, FileText, X } from "lucide-react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from "@/components/ui/dialog";
-import { IVacationRequest } from "@/components/company/table/VacationColumns";
-import { X } from "lucide-react";
 import { StatusBadge } from "@/components/company/table/VacationColumns";
+import { IVacationRequest } from "@/components/company/table/VacationColumns";
 import { useVacationDetailModal } from "@/hooks/manager/useVacationDetailModal";
 
 interface IVacationDetailModalProps {
@@ -19,80 +12,74 @@ interface IVacationDetailModalProps {
   onReject: (id: string) => void;
 }
 
-const VacationDetailModal: React.FC<IVacationDetailModalProps> = ({
+const VacationDetailModal = ({
   request,
   onClose,
   onApprove,
   onReject,
-}) => {
+}: IVacationDetailModalProps) => {
   if (!request) return null;
 
-  const { isPending, detailRows, handleApproveClick, handleRejectClick } = useVacationDetailModal(
-    request,
-    onApprove,
-    onReject,
-    onClose,
-  );
+  const { isPending, detailRows, displayRequestDate, handleApproveClick, handleRejectClick } =
+    useVacationDetailModal(request, onApprove, onReject, onClose);
 
   return (
     <Dialog open={true} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="w-[90vw] max-w-md dark:text-white-text">
         <DialogHeader>
-          <DialogTitle className="flex justify-center dark:text-white-text">상세 정보</DialogTitle>
-          <button
-            onClick={onClose}
-            className="absolute right-5 top-7 rounded-md border-none bg-transparent text-muted-foreground hover:text-dark-card-bg"
-          >
-            <X size={20} strokeWidth={3} />
-          </button>
+          <DialogTitle className="flex items-center justify-between gap-2 text-lg dark:text-gray-900">
+            <div className="flex items-center gap-2">
+              <PlaneTakeoff className="h-5 w-5 text-primary dark:text-gray-900" />
+              <span>휴가 상세 정보</span>
+            </div>
+
+            <StatusBadge status={request.status} />
+          </DialogTitle>
         </DialogHeader>
 
-        <div className="mb-3 grid gap-6 py-4">
-          <div className="flex gap-5">
-            {detailRows.slice(0, 2).map(({ label, value }) => (
-              <div
-                key={label}
-                className="w-full rounded-md border bg-white-bg px-3 py-4 dark:bg-white-bg"
-              >
-                <strong>{label} :</strong> {value}
-              </div>
-            ))}
+        {/* 상세 정보 */}
+        <div className="mt-6 space-y-4 text-foreground dark:text-gray-900">
+          <div className="flex items-center gap-2">
+            <User className="h-4 w-4 text-muted-foreground" />
+            <span className="font-medium">이름:</span> {request.requester.name}
           </div>
-          {detailRows.slice(2).map(({ label, value }) => (
-            <div key={label} className="rounded-md border bg-white-bg px-3 py-4 dark:bg-white-bg">
-              <strong>{label} :</strong> {value}
-            </div>
-          ))}
-          <div className="whitespace-pre-wrap break-words rounded-md border bg-white-bg px-3 py-4 dark:bg-white-bg">
-            <strong>사유 : </strong>
-            <div className="mt-3">{request.reason}</div>
+
+          <div className="flex items-center gap-2">
+            <BadgeCheck className="h-4 w-4 text-muted-foreground" />
+            <span className="font-medium">직무:</span> {request.requester.jobName}
           </div>
-          {!isPending && (
-            <p className="flex items-center justify-end gap-2">
-              <strong>처리 상태 : </strong> <StatusBadge status={request.status} />
-            </p>
-          )}
+
+          <div className="flex items-center gap-2">
+            <Calendar className="h-4 w-4 text-muted-foreground" />
+            <span className="font-medium">기간:</span> {displayRequestDate}
+            <span className="rounded-full border-2 border-solid border-blue-500 px-3 text-xs font-extrabold text-blue-500">
+              {request.requestType}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <FileText className="mt-1 h-4 w-4 text-muted-foreground" />
+            <span className="font-medium">사유:</span>
+            <div className="whitespace-pre-wrap break-words">{request.reason}</div>
+          </div>
         </div>
 
-        {isPending && (
-          <DialogFooter className="flex flex-row gap-2">
-            <Button
-              variant="default"
-              size="sm"
-              className="w-full bg-green-500 hover:bg-green-600"
-              onClick={handleApproveClick}
-            >
+        {/* 처리 버튼 or 닫기 */}
+        {isPending ? (
+          <div className="mt-10 flex gap-2">
+            <Button className="w-full bg-green-500 hover:bg-green-600" onClick={handleApproveClick}>
               승인
             </Button>
-            <Button
-              variant="default"
-              size="sm"
-              className="w-full bg-red-500 hover:bg-red-600"
-              onClick={handleRejectClick}
-            >
+            <Button className="w-full bg-red-500 hover:bg-red-600" onClick={handleRejectClick}>
               거절
             </Button>
-          </DialogFooter>
+          </div>
+        ) : (
+          <div className="mt-6 flex justify-end">
+            <Button variant="outline" onClick={onClose}>
+              닫기
+            </Button>
+          </div>
         )}
       </DialogContent>
     </Dialog>

--- a/src/Components/common/modal/VacationRegisterModal.tsx
+++ b/src/Components/common/modal/VacationRegisterModal.tsx
@@ -47,7 +47,7 @@ const VacationRegisterModal: React.FC<IVacationModalProps> = ({ onClose, onRegis
 
   return (
     <Dialog open={true} onOpenChange={onClose}>
-      <DialogContent className="dark:border dark:border-dark-border sm:max-w-md">
+      <DialogContent className="w-full max-w-[350px] rounded-xl px-4 py-6 dark:border dark:border-dark-border sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex justify-center dark:text-white-text">휴가 등록</DialogTitle>
           <button
@@ -72,15 +72,15 @@ const VacationRegisterModal: React.FC<IVacationModalProps> = ({ onClose, onRegis
           <div className="flex flex-col gap-2">
             <span className="font-medium">휴가 유형</span>
             <Select value={vacationType} onValueChange={setVacationType}>
-              <SelectTrigger className="dark:text-white-text">
+              <SelectTrigger className="w-full max-w-xs dark:text-white-text sm:max-w-md">
                 <SelectValue placeholder="휴가 유형 선택" />
               </SelectTrigger>
-              <SelectContent className="dark:border dark:border-dark-border dark:bg-white-card-bg dark:text-white-text">
+              <SelectContent className="w-full min-w-0 dark:border dark:border-dark-border dark:bg-white-card-bg dark:text-white-text">
                 {VACATIONSELECT_TYPES.map(type => (
                   <SelectItem
                     key={type}
                     value={type}
-                    className="dark:text-white-text dark:hover:bg-white-bg"
+                    className="w-full min-w-0 dark:text-white-text dark:hover:bg-white-bg"
                   >
                     {type}
                   </SelectItem>
@@ -114,7 +114,7 @@ const VacationRegisterModal: React.FC<IVacationModalProps> = ({ onClose, onRegis
           <div className="flex flex-col gap-2">
             <span>사유</span>
             <textarea
-              className="h-20 w-full rounded-md text-base"
+              className="h-20 w-full min-w-0 max-w-xs rounded-md border p-1 text-base sm:max-w-md"
               value={reason}
               onChange={e => setReason(e.target.value)}
             ></textarea>

--- a/src/Components/ui/data-table.tsx
+++ b/src/Components/ui/data-table.tsx
@@ -79,7 +79,7 @@ export function DataTable<TData>({ columns, data, onRowClick }: DataTableProps<T
           ) : (
             <TableRow className="h-[500px]">
               <TableCell colSpan={columns.length} className="w-full p-5 text-center text-lg">
-                결과 없음
+                데이터가 없습니다.
               </TableCell>
             </TableRow>
           )}

--- a/src/Components/ui/date-range-picker.tsx
+++ b/src/Components/ui/date-range-picker.tsx
@@ -23,6 +23,8 @@ export function DateRangePicker({
   vacationType: string;
   handleDateChange: (range: DateRange | undefined) => void;
 }) {
+  const isMobile = window.innerWidth <= 640;
+
   return (
     <div className={cn("grid gap-2", className)}>
       <Popover>
@@ -31,7 +33,7 @@ export function DateRangePicker({
             id="date"
             variant="outline"
             className={cn(
-              "w-[400px] justify-start text-left font-normal",
+              "w-full max-w-xs justify-start text-left font-normal sm:max-w-md",
               !date && "text-muted-foreground",
             )}
           >
@@ -71,7 +73,7 @@ export function DateRangePicker({
               defaultMonth={date?.from}
               selected={date}
               onSelect={handleDateChange}
-              numberOfMonths={2}
+              numberOfMonths={isMobile ? 1 : 2}
               toDate={toDate}
             />
           )}

--- a/src/hooks/manager/useVacationDetailModal.ts
+++ b/src/hooks/manager/useVacationDetailModal.ts
@@ -19,7 +19,8 @@ export const useVacationDetailModal = (
     : request.requestDate;
 
   const detailRows = [
-    { label: "휴가자", value: request.requester.name },
+    { label: "이름", value: request.requester.name },
+    { label: "직무", value: request.requester.jobName },
     { label: "휴가 유형", value: request.requestType },
     { label: "이메일", value: request.email ?? "-" },
     { label: "휴가 일자", value: displayRequestDate },
@@ -49,6 +50,7 @@ export const useVacationDetailModal = (
 
   return {
     isPending,
+    displayRequestDate,
     detailRows,
     handleApproveClick,
     handleRejectClick,

--- a/src/pages/manager/VacationDetailPage.tsx
+++ b/src/pages/manager/VacationDetailPage.tsx
@@ -9,6 +9,7 @@ import VacationRequestPageContainer from "@/components/container/manager/Vacatio
 import VacationDetailModal from "@/components/common/modal/VacationDetailModal";
 import VacationTabContent from "@/components/company/table/VacationTabContent";
 import Seo from "@/components/Seo";
+import { Plus } from "lucide-react";
 
 const VacationDetailPage = () => {
   const {
@@ -68,10 +69,13 @@ const VacationDetailPage = () => {
             </TabsList>
 
             <Button
-              className="mt-4 cursor-pointer bg-white-bg font-extrabold text-white-text hover:bg-white-bg dark:bg-dark-bg dark:text-dark-text"
+              className="group mt-4 flex cursor-pointer items-center gap-2 bg-white-bg text-sm font-bold text-white-text hover:bg-white-bg hover:font-extrabold dark:bg-dark-bg dark:text-dark-text sm:text-base"
               onClick={toggleModal}
             >
-              휴가 등록 +
+              <span className="flex h-5 w-5 -translate-y-0.5 translate-x-0.5 items-center justify-center rounded-full border-2 border-solid border-white-text text-white-text transition-colors group-hover:bg-dark-card-bg group-hover:font-extrabold group-hover:text-dark-text dark:border-dark-text dark:text-dark-text dark:hover:text-white-text dark:group-hover:bg-white-card-bg dark:group-hover:text-black">
+                <Plus className="h-4 w-4" />
+              </span>
+              <span className="transition-all group-hover:font-extrabold">휴가 등록</span>
             </Button>
           </div>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #200 

## 📝작업 내용

> 휴가 등록 버튼 디자인 및 등록 모달 수정
- 휴가등록 버튼에 아이콘을 추가해서 넣었습니다.
<img width="424" alt="스크린샷 2025-05-09 오전 4 45 27" src="https://github.com/user-attachments/assets/de228363-77f0-45b9-82ff-1c751eff5ee8" />
<img width="412" alt="스크린샷 2025-05-09 오전 4 45 33" src="https://github.com/user-attachments/assets/318b63c8-6c14-42c9-b750-887cf29d9f80" /><br/><br/>

> 휴가 등록 모달 반응형
- 너비 요소가 넘치는 현상을 수정하였습니다.
- textarea의 테두리를 추가하였습니다.
<img width="386" alt="스크린샷 2025-05-09 오전 4 51 42" src="https://github.com/user-attachments/assets/795e3928-dfc3-47c9-b892-26e55d5d5e55" />

> 휴가 상세 정보
- 직원(모바일) 휴가 상세 정보 컴포넌트를 재사용하여 UI를 개선하였습니다.
- requestType부분을 기존에 status옆에 배치되었는데 기간 부분 옆에 두는게 더 이상적인 생각인데 어떻게 생각하시는지 여쭤보겠습니다.
<img width="574" alt="스크린샷 2025-05-09 오전 4 53 48" src="https://github.com/user-attachments/assets/a307da9a-c3e0-4457-aa43-1796727e4ac2" />
<img width="547" alt="스크린샷 2025-05-09 오전 4 53 56" src="https://github.com/user-attachments/assets/c87ea123-f3eb-4291-bdd9-554bcd27dcb4" />

> 휴가 테이블에 데이터가 없을 때, 텍스트 문장형으로 변경
- 좀 더 자세한 텍스트를 작성하려다가 여러곳에 테이블이 재사용되다 보니 공통적인 메시지를 작성했습니다.
<img width="1285" alt="스크린샷 2025-05-09 오전 4 55 45" src="https://github.com/user-attachments/assets/7bb11822-46bf-4ccd-aa54-448e336e7cec" />


## 💬리뷰 요구사항(선택)
- 노션에 "모바일때, 주간 변경 고려" 라는 QA가 있는데 혹시 어느 부분인지 알려주시면 수정하겠습니다.
