### PR TITLE
[#202] : period attendance qa

### DIFF
--- a/src/Components/company/attendance/PeriodAttCalendarDayCard.tsx
+++ b/src/Components/company/attendance/PeriodAttCalendarDayCard.tsx
@@ -1,8 +1,10 @@
 import { Card } from "@/components/ui/card";
 import { useNavigate, useParams } from "react-router-dom";
+import { format } from "date-fns";
 
 interface Props {
   day: number;
+  fullDate: Date;
   isSunday: boolean;
   isCompanyHoliday?: boolean;
   variant?: "total" | "employee";
@@ -24,6 +26,7 @@ interface Props {
 
 const PeriodAttCalendarDayCard = ({
   day,
+  fullDate,
   isSunday,
   isCompanyHoliday,
   variant = "total",
@@ -38,19 +41,20 @@ const PeriodAttCalendarDayCard = ({
     <Card
       onClick={() => {
         if (variant === "total" && companyCode) {
-          navigate(`/${companyCode}/todayatt`);
+          const formattedDate = format(fullDate, "yyyy-MM-dd");
+          navigate(`/${companyCode}/todayatt?date=${formattedDate}`);
         }
       }}
-      className="hover:bg-white-hover flex h-[120px] cursor-pointer flex-col justify-between rounded-none border-[0.5px] border-solid border-white-border-sub p-2 text-sm dark:border-dark-border-sub dark:hover:bg-white-border sm:h-[140px] md:h-[160px] lg:h-[120px]"
+      className="flex h-[120px] cursor-pointer flex-col justify-between rounded-none border-[0.5px] border-solid border-white-border-sub p-2 text-sm hover:bg-white-hover dark:border-dark-border-sub dark:hover:bg-white-border sm:h-[140px] md:h-[160px] lg:h-[120px]"
     >
       {/* 상단 날짜 */}
       <div className="mb-1 flex items-center justify-between text-[15px] font-medium">
         <span
           className={
             isSunday
-              ? "flex h-6 w-6 items-center justify-center rounded-full bg-red-500 text-[15px] text-dark-text dark:bg-red-500"
+              ? "flex h-6 w-6 items-center justify-center rounded-full bg-red-500 pt-0.5 text-[15px] text-dark-text dark:bg-red-500"
               : isCompanyHoliday
-                ? "flex h-6 w-6 items-center justify-center rounded-full bg-yellow-400 text-[15px] text-dark-text dark:bg-yellow-500"
+                ? "flex h-6 w-6 items-center justify-center rounded-full bg-yellow-400 pt-0.5 text-[15px] text-dark-text dark:bg-yellow-500"
                 : "text-muted-foreground"
           }
         >

--- a/src/Components/company/attendance/PeriodAttCalendarDayCard.tsx
+++ b/src/Components/company/attendance/PeriodAttCalendarDayCard.tsx
@@ -77,7 +77,7 @@ const PeriodAttCalendarDayCard = ({
               key={item.label}
               className="flex items-center gap-1 overflow-hidden text-ellipsis whitespace-nowrap rounded border-2 border-solid border-white-border-sub px-2 py-1 text-[13px] dark:border-dark-border-sub"
             >
-              <span className={`h-3 w-1.5 rounded-full ${item.color}`} />
+              <span className={`h-1.5 w-1.5 rounded-full ${item.color}`} />
               <span className="truncate">{item.label}</span>
               <span className="ml-auto font-semibold">{item.value}</span>
             </div>

--- a/src/Components/company/attendance/PeriodAttCalendarGrid.tsx
+++ b/src/Components/company/attendance/PeriodAttCalendarGrid.tsx
@@ -6,7 +6,6 @@ import dayjs from "dayjs";
 import { EmployeeInfo } from "@/model/types/user.type";
 import { TCalendarDayInfo } from "@/model/types/commute.type";
 
-
 const DAYS = ["일", "월", "화", "수", "목", "금", "토"];
 
 interface Props {
@@ -56,7 +55,7 @@ const PeriodAttCalendarGrid = ({
 
   return (
     <div className="overflow-hidden rounded-lg border border-white-border-sub px-6 pb-6 dark:border-dark-border-sub">
-      <div className="dark:bg-vacation-dark-color sticky top-0 rounded-t-lg bg-vacation-color py-4 pl-6 text-left text-base font-semibold text-dark-text">
+      <div className="sticky top-0 rounded-t-lg bg-vacation-color py-4 pl-6 text-left text-base font-semibold text-dark-text dark:bg-vacation-dark-color">
         {variant === "total"
           ? `${workplace === "전체" ? "전체" : workplace} 근태 현황`
           : `${selectedEmployee?.name ?? "직원"}님의 근태 현황`}
@@ -73,18 +72,25 @@ const PeriodAttCalendarGrid = ({
           const isSunday = idx % 7 === 0;
           const isSaturday = idx % 7 === 6;
 
-          return data ? (
-            <PeriodAttCalendarDayCard
-              key={idx}
-              day={data.day}
-              summary={data.summary}
-              checkIn={data.checkIn}
-              checkOut={data.checkOut}
-              isSunday={isSunday}
-              isCompanyHoliday={data.isCompanyHoliday}
-              variant={variant}
-            />
-          ) : (
+          if (data) {
+            const fullDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), data.day); // ✅ 여기서 fullDate 생성
+
+            return (
+              <PeriodAttCalendarDayCard
+                key={idx}
+                day={data.day}
+                fullDate={fullDate}
+                summary={data.summary}
+                checkIn={data.checkIn}
+                checkOut={data.checkOut}
+                isSunday={isSunday}
+                isCompanyHoliday={data.isCompanyHoliday}
+                variant={variant}
+              />
+            );
+          }
+
+          return (
             <Card
               key={idx}
               className="h-[120px] rounded-none border-[0.5px] border-solid border-white-border-sub dark:border-dark-border-sub sm:h-[140px] md:h-[160px] lg:h-[120px]"


### PR DESCRIPTION
## #️⃣연관된 이슈

> #202 

## 📝작업 내용

> 특정 날짜 클릭 시, 해당하는 날짜에 대한 금일 출퇴근 페이지 쿼리스트링 연결
- 어떤 날짜를 클릭하던 현재 날짜로 페이지가 이동하는 현상을 수정하였습니다.
- 달력 UI는 알록달록함을 줄이기 위해서 라벨부분에 있는 색상(원)들을 수정하였습니다.
![스크린샷 2025-05-12 오전 5 01 09](https://github.com/user-attachments/assets/82a44e33-4e6f-4797-8219-01896db9f269)
![스크린샷 2025-05-12 오전 5 01 27](https://github.com/user-attachments/assets/29d5a190-1ae3-4066-b245-54a30e05a56b)

> 국가 지정 공휴일 라이브러리 적용
- 공휴일 라이브러리 설치X 그 이유는 npm 공식 레지스트리에는 존재하지 않음
- 대안으로 api 연동이 있지만 키 노출 위험으로 백엔드 또는 프록시 필요
- 프론트단에서 해결하려면 수동으로 처리해야 하지만 음력도 존재하기 떄문에 구현 어려움

> 직원 정산
- 이 부분은 다른페이지도 관여되기 때문에 다른 페이지의 QA를 해결하고 2차QA에서 작업 예정입니다.
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
