### PR TITLE
[#211] : employee home qa

### DIFF
--- a/src/Components/common/DarkmodeToggle.tsx
+++ b/src/Components/common/DarkmodeToggle.tsx
@@ -1,0 +1,25 @@
+import { Moon, Sun } from "lucide-react";
+import { cn } from "@/util/cn.util";
+import { useShallow } from "zustand/shallow";
+import useDarkMode from "@/store/darkmode.store";
+
+const DarkmodeToggle = ({ className }: { className?: string }) => {
+  const { toggleMode, darkMode } = useDarkMode(
+    useShallow(state => ({
+      toggleMode: state.toggleMode,
+      darkMode: state.darkMode,
+    })),
+  );
+
+  return (
+    <button onClick={toggleMode} className={cn("p-1", className)}>
+      {darkMode ? (
+        <Sun className="text-orange-400" size={20} />
+      ) : (
+        <Moon className="text-yellow-300" size={20} />
+      )}
+    </button>
+  );
+};
+
+export default DarkmodeToggle;

--- a/src/Components/common/Header.tsx
+++ b/src/Components/common/Header.tsx
@@ -5,7 +5,7 @@ import NavTitle from "./NavTitle";
 import { useCompanyStore } from "@/store/company.store";
 import AppTitle from "./AppTitle";
 import NotificationBell from "./NotificationBell";
-
+import DarkmodeToggle from "./DarkmodeToggle";
 
 interface HeaderProps {
   variant?: "employee" | "manager";
@@ -33,9 +33,9 @@ export default function Header({ variant = "manager" }: HeaderProps) {
     <div className="fixed left-1/2 top-0 z-50 h-12 w-full max-w-screen-sm -translate-x-1/2 border-b bg-dark-card-bg px-4 shadow-md dark:bg-dark-bg sm:h-14 md:h-16">
       <div className="flex h-full w-full items-center justify-between">
         <AppTitle className="text-base text-white" />
-        <div className="flex items-center gap-5">
+        <div className="flex items-center gap-3">
+          <DarkmodeToggle />
           <NotificationBell />
-          <DarkmodeSwitch />
         </div>
       </div>
     </div>

--- a/src/Components/common/menubar/manager/ManagerMenuBarItem.tsx
+++ b/src/Components/common/menubar/manager/ManagerMenuBarItem.tsx
@@ -4,6 +4,7 @@ import { useMenuBar } from "@/hooks/menu/useMenuBar";
 import { cn } from "@/util/cn.util";
 import { useNavigate } from "react-router-dom";
 import { useVacationRequests } from "@/hooks/manager/useVacationRequests";
+import { useSidebar } from "@/components/ui/sidebar";
 
 interface ManagerMenuItemProps {
   section: {
@@ -21,9 +22,11 @@ const ManagerMenuBarItem = ({ section }: ManagerMenuItemProps) => {
     requests: { pendingCount },
   } = useVacationRequests();
   const navigate = useNavigate();
+  const { setOpenMobile, isMobile } = useSidebar();
 
   const handleNavigation = (path: string) => {
     navigate(`/${companyCode ?? ""}${path}`);
+    if (isMobile) setOpenMobile(false);
   };
 
   return (

--- a/src/Components/common/modal/NoticeModal.tsx
+++ b/src/Components/common/modal/NoticeModal.tsx
@@ -34,7 +34,7 @@ const NoticeModal = ({ onClose, onSave }: NoticeModalProps) => {
     onSave({
       title,
       content,
-      createdAt: format(new Date(), "yyyy.MM.dd"),
+      createdAt: new Date().toISOString(),
       noticeType,
     });
     setTitle("");

--- a/src/Components/company/notice/NoticeCard.tsx
+++ b/src/Components/company/notice/NoticeCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { X } from "lucide-react";
+import { format, parseISO } from "date-fns";
 
 interface NoticeCardProps {
   title: string;
@@ -47,7 +48,7 @@ const NoticeCard = ({ title, content, createdAt, onDelete, noticeType }: NoticeC
       </div>
 
       <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
-        <span>{createdAt}</span>
+        <span>{createdAt?.split("T")[0] ?? "-"}</span>
         {content.length > 40 && (
           <button
             onClick={() => setOpen(prev => !prev)}

--- a/src/Components/ui/notificationDropdown.tsx
+++ b/src/Components/ui/notificationDropdown.tsx
@@ -54,53 +54,58 @@ const NotificationDropdown = ({
         <p className="py-4 text-center text-sm text-muted-foreground">새로운 알림이 없습니다.</p>
       ) : (
         <ul className="max-h-[300px] overflow-y-auto">
-          {notifications.map(({ id, data }) => (
-            <li
-              key={id}
-              className="dark:hover:bg-dark-hover group flex flex-col rounded-md px-2 py-3 text-sm hover:bg-white-hover"
-            >
-              <div className="flex items-center justify-between gap-2">
-                <div
-                  className="flex flex-1 cursor-pointer items-center gap-2"
-                  onClick={async () => {
-                    await onClickNotification(id);
-                    onCloseDropdown();
-                    navigate(getLink(data.type, data.relatedId));
-                  }}
-                >
-                  {getIcon(data.type)}
-                  <span>{data.message}</span>
+          {notifications
+            .filter(({ data }) => data.message) // ✅ message 없는 알림 제거
+            .sort(
+              (a, b) => new Date(b.data.createdAt).getTime() - new Date(a.data.createdAt).getTime(),
+            )
+            .map(({ id, data }) => (
+              <li
+                key={id}
+                className="dark:hover:bg-dark-hover group flex flex-col rounded-md px-2 py-3 text-sm hover:bg-white-hover"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div
+                    className="flex flex-1 cursor-pointer items-center gap-2"
+                    onClick={async () => {
+                      await onClickNotification(id);
+                      onCloseDropdown();
+                      navigate(getLink(data.type, data.relatedId));
+                    }}
+                  >
+                    {getIcon(data.type)}
+                    <span>{data.message}</span>
+                  </div>
+
+                  <span className="whitespace-nowrap text-[10px] text-muted-foreground">
+                    {formatDistanceToNow(new Date(data.createdAt), {
+                      addSuffix: true,
+                      locale: ko,
+                    })}
+                  </span>
+
+                  <button
+                    className="rounded p-1 text-xs text-gray-400 hover:text-red-500"
+                    onClick={() => onClickNotification(id, false)}
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
                 </div>
 
-                <span className="whitespace-nowrap text-[10px] text-muted-foreground">
-                  {formatDistanceToNow(new Date(data.createdAt), {
-                    addSuffix: true,
-                    locale: ko,
-                  })}
-                </span>
+                {data.requestDate &&
+                  (() => {
+                    const [start, end] = data.requestDate.split(" ~ ");
+                    const formattedStart = format(parseISO(start), "yy.MM.dd");
+                    const formattedEnd = format(parseISO(end), "yy.MM.dd");
 
-                <button
-                  className="rounded p-1 text-xs text-gray-400 hover:text-red-500"
-                  onClick={() => onClickNotification(id, false)}
-                >
-                  <X className="h-3.5 w-3.5" />
-                </button>
-              </div>
-
-              {data.requestDate &&
-                (() => {
-                  const [start, end] = data.requestDate.split(" ~ ");
-                  const formattedStart = format(parseISO(start), "yy.MM.dd");
-                  const formattedEnd = format(parseISO(end), "yy.MM.dd");
-
-                  return (
-                    <p className="ml-6 mt-1 text-xs text-dark-nav-text">
-                      요청 일자: {formattedStart} ~ {formattedEnd}
-                    </p>
-                  );
-                })()}
-            </li>
-          ))}
+                    return (
+                      <p className="ml-6 mt-1 text-xs text-dark-nav-text">
+                        요청 일자: {formattedStart} ~ {formattedEnd}
+                      </p>
+                    );
+                  })()}
+              </li>
+            ))}
         </ul>
       )}
     </div>

--- a/src/Components/ui/notificationDropdown.tsx
+++ b/src/Components/ui/notificationDropdown.tsx
@@ -49,7 +49,7 @@ const NotificationDropdown = ({
   };
 
   return (
-    <div className="absolute right-1 mt-2 w-[300px] rounded-md border border-white-border bg-white p-2 shadow-md dark:border-dark-border dark:bg-dark-card-bg">
+    <div className="fixed left-0 right-0 top-12 z-50 w-full rounded-md border border-white-border bg-white p-2 shadow-md dark:border-dark-border dark:bg-dark-card-bg sm:top-14 md:top-16">
       {notifications.length === 0 ? (
         <p className="py-4 text-center text-sm text-muted-foreground">새로운 알림이 없습니다.</p>
       ) : (
@@ -57,7 +57,7 @@ const NotificationDropdown = ({
           {notifications.map(({ id, data }) => (
             <li
               key={id}
-              className="hover:bg-white-hover dark:hover:bg-dark-hover group flex flex-col rounded-md px-2 py-2 text-sm"
+              className="dark:hover:bg-dark-hover group flex flex-col rounded-md px-2 py-3 text-sm hover:bg-white-hover"
             >
               <div className="flex items-center justify-between gap-2">
                 <div


### PR DESCRIPTION
## #️⃣연관된 이슈

> #211 

## 📝작업 내용

> 헤더 컴포넌트 및 알림 창 크기 변경
- 헤더에 있는 알림과 다크모드의 위치를 변경하고 다크모드를 스위치 대신 토글로 변경하였습니다.
- 알림 창 너비를 w-full로 조정했습니다.

<img width="377" alt="스크린샷 2025-05-14 오전 1 58 58" src="https://github.com/user-attachments/assets/fbf22f87-7c6c-4085-8199-3ed9dc79289e" /><br/><br/>

> 직원 홈 공지사항 박스 변경
- 공지사항 api를 활용하여 최신 공지사항 1개를 가져와 보여줍니다.
- 최신 공지사항이 올라오면 빨간 점 표시로 가시성을 부여했습니다.
- 다음 공지까지 3일 이상 게시되지 않으면 빨간 점은 사라집니다.

<img width="380" alt="스크린샷 2025-05-14 오전 2 03 03" src="https://github.com/user-attachments/assets/8d2c5575-ef07-4c65-b398-cd7c105242c5" />

> 관리자 모바일ver. 사이드바 닫힘 오류 수정
- 기존에는 사이드바에 있는 특정 메뉴 클릭 시, 화면은 바뀌지만 사이드바는 닫히지 않던 현상을 수정하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
