### PR TITLE
[#219] : 공지사항 페이지 기능 투어 추가

### DIFF
--- a/src/Components/common/TourController.tsx
+++ b/src/Components/common/TourController.tsx
@@ -1,0 +1,41 @@
+import Joyride, { CallBackProps, STATUS, Step } from "react-joyride";
+
+interface TourControllerProps {
+  steps: Step[];
+  run: boolean;
+  onClose: () => void;
+}
+
+const TourController = ({ steps, run, onClose }: TourControllerProps) => {
+  const handleCallback = (data: CallBackProps) => {
+    const { status } = data;
+    if (status === STATUS.FINISHED || status === STATUS.SKIPPED) {
+      onClose();
+    }
+  };
+
+  if (!run || steps.length === 0) return null;
+
+  return (
+    <Joyride
+      steps={steps}
+      run={run}
+      callback={handleCallback}
+      continuous
+      showProgress
+      showSkipButton
+      scrollToFirstStep
+      disableScrolling={true}
+      spotlightClicks={false}
+      disableOverlayClose={true}
+      styles={{
+        options: {
+          zIndex: 10000,
+          primaryColor: "#6366f1",
+        },
+      }}
+    />
+  );
+};
+
+export default TourController;

--- a/src/constants/managerTourSteps.ts
+++ b/src/constants/managerTourSteps.ts
@@ -1,0 +1,15 @@
+import { Step } from "react-joyride";
+
+export const noticeTourSteps: Step[] = [
+  {
+    target: '[data-tour="step-1"]',
+    content: "여기서 전체 공지사항 수를 확인할 수 있어요.",
+    disableBeacon: true,
+    placement: "bottom",
+  },
+  {
+    target: '[data-tour="step-2"]',
+    content: "새로운 공지사항을 작성할 수 있어요.",
+    disableBeacon: true,
+  },
+];

--- a/src/hooks/use-tour.ts
+++ b/src/hooks/use-tour.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { Step } from "react-joyride";
+import { useUserStore } from "@/store/user.store";
+import { useTourStore } from "@/store/tour.store";
+import { hasSeenTour, markTourAsSeen } from "@/util/tourStorage.util";
+
+export const useTour = (pageKey: string, steps: Step[], dependencyReady: boolean = true) => {
+  const [runTour, setRunTour] = useState(false);
+  const userId = useUserStore(state => state.currentUser?.uid);
+
+  // steps 등록 (공통)
+  useEffect(() => {
+    useTourStore.getState().setSteps(steps);
+  }, [steps]);
+
+  // 최초 페이지 진입 시 투어 실행
+  useEffect(() => {
+    if (!userId || !dependencyReady) return;
+
+    const hasSeen = hasSeenTour(pageKey, userId);
+    if (!hasSeen) {
+      setRunTour(true);
+      markTourAsSeen(pageKey, userId);
+    }
+  }, [userId, dependencyReady]);
+
+  return {
+    runTour,
+    setRunTour,
+  };
+};

--- a/src/hooks/use-tour.ts
+++ b/src/hooks/use-tour.ts
@@ -7,6 +7,7 @@ import { hasSeenTour, markTourAsSeen } from "@/util/tourStorage.util";
 export const useTour = (pageKey: string, steps: Step[], dependencyReady: boolean = true) => {
   const [runTour, setRunTour] = useState(false);
   const userId = useUserStore(state => state.currentUser?.uid);
+  const setRun = useTourStore(state => state.setRun);
 
   // steps 등록 (공통)
   useEffect(() => {
@@ -18,8 +19,10 @@ export const useTour = (pageKey: string, steps: Step[], dependencyReady: boolean
     if (!userId || !dependencyReady) return;
 
     const hasSeen = hasSeenTour(pageKey, userId);
+    console.log(`[투어] hasSeen: ${hasSeen}, uid: ${userId}, pageKey: ${pageKey}`);
     if (!hasSeen) {
-      setRunTour(true);
+      console.log("[투어] 자동 실행 시작!");
+      setRun(true);
       markTourAsSeen(pageKey, userId);
     }
   }, [userId, dependencyReady]);

--- a/src/layout/ManagerLayout.tsx
+++ b/src/layout/ManagerLayout.tsx
@@ -26,25 +26,6 @@ const Layout = () => {
   return (
     <SidebarProvider>
       <TourController steps={steps} run={runTour} onClose={() => setRunTour(false)} />
-      {/* <Joyride
-        steps={steps}
-        run={runTour}
-        continuous
-        showSkipButton
-        showProgress
-        scrollToFirstStep
-        styles={{
-          options: {
-            zIndex: 10000,
-            primaryColor: "#6366f1",
-          },
-        }}
-        callback={({ status }) => {
-          if (["finished", "skipped"].includes(status)) {
-            setRunTour(false);
-          }
-        }}
-      /> */}
 
       <div className="relative flex min-h-screen w-screen bg-white-bg text-white-text dark:bg-dark-bg dark:text-dark-text">
         <MenuBar />

--- a/src/layout/ManagerLayout.tsx
+++ b/src/layout/ManagerLayout.tsx
@@ -8,8 +8,9 @@ import TourController from "@/components/common/TourController";
 import { useTourStore } from "@/store/tour.store";
 
 const Layout = () => {
-  const [runTour, setRunTour] = useState(false);
   const steps = useTourStore(state => state.steps);
+  const runTour = useTourStore(state => state.run);
+  const setRunTour = useTourStore(state => state.setRun);
 
   const handleStartTour = () => {
     const target = document.querySelector('[data-tour="step-1"]');

--- a/src/layout/ManagerLayout.tsx
+++ b/src/layout/ManagerLayout.tsx
@@ -1,16 +1,31 @@
 import React, { useState } from "react";
-import Joyride, { Step } from "react-joyride";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import MenuBar from "@/components/common/menubar/MenuBar";
 import Header from "@/components/common/Header";
 import { Outlet } from "react-router-dom";
 import { HelpCircle } from "lucide-react";
+import TourController from "@/components/common/TourController";
+import { useTourStore } from "@/store/tour.store";
 
 const Layout = () => {
-  // const [runTour, setRunTour] = useState(false);
+  const [runTour, setRunTour] = useState(false);
+  const steps = useTourStore(state => state.steps);
+
+  const handleStartTour = () => {
+    const target = document.querySelector('[data-tour="step-1"]');
+
+    if (target) {
+      target.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+
+    setTimeout(() => {
+      setRunTour(true);
+    }, 300);
+  };
 
   return (
     <SidebarProvider>
+      <TourController steps={steps} run={runTour} onClose={() => setRunTour(false)} />
       {/* <Joyride
         steps={steps}
         run={runTour}
@@ -42,11 +57,11 @@ const Layout = () => {
           </main>
 
           <button
-            // onClick={() => setRunTour(true)}
+            onClick={handleStartTour}
             className="fixed bottom-6 right-6 z-50 rounded-full bg-point-color p-3 text-white shadow-lg transition-all ease-out hover:bg-yellow-500"
             aria-label="도움말"
           >
-            <HelpCircle className="h-6 w-6" />
+            <HelpCircle className="h-7 w-7" />
           </button>
         </div>
       </div>

--- a/src/pages/manager/NoticePage.tsx
+++ b/src/pages/manager/NoticePage.tsx
@@ -10,7 +10,6 @@ import { deleteNotice } from "@/api/notice.api";
 import { ChevronUp, Megaphone } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { noticeTourSteps } from "@/constants/managerTourSteps";
-import TourController from "@/components/common/TourController";
 import { useTour } from "@/hooks/use-tour";
 
 const NoticePage = () => {
@@ -21,7 +20,8 @@ const NoticePage = () => {
   const { toast } = useToast();
 
   // 투어관련 커스텀 훅
-  const { runTour, setRunTour } = useTour("notice", noticeTourSteps, notices.length > 0);
+  console.log("[투어] useTour 호출됨");
+  useTour("notice", noticeTourSteps);
 
   const [page, setPage] = useState(1);
   const noticesPerPage = 6;
@@ -74,8 +74,6 @@ const NoticePage = () => {
 
   return (
     <>
-      <TourController steps={noticeTourSteps} run={runTour} onClose={() => setRunTour(false)} />
-
       <Seo title="공지사항 | On & Off" description="On & Off에서 근태관리 서비스를 이용해보세요." />
 
       <div className="flex w-full flex-col gap-4 sm:py-2">

--- a/src/pages/manager/NoticePage.tsx
+++ b/src/pages/manager/NoticePage.tsx
@@ -9,6 +9,9 @@ import { useUserStore } from "@/store/user.store";
 import { deleteNotice } from "@/api/notice.api";
 import { ChevronUp, Megaphone } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
+import { noticeTourSteps } from "@/constants/managerTourSteps";
+import TourController from "@/components/common/TourController";
+import { useTour } from "@/hooks/use-tour";
 
 const NoticePage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -16,6 +19,9 @@ const NoticePage = () => {
   const userType = useUserStore(state => state.currentUser?.userType);
   const companyCode = useUserStore(state => state.currentUser?.companyCode);
   const { toast } = useToast();
+
+  // 투어관련 커스텀 훅
+  const { runTour, setRunTour } = useTour("notice", noticeTourSteps, notices.length > 0);
 
   const [page, setPage] = useState(1);
   const noticesPerPage = 6;
@@ -68,16 +74,24 @@ const NoticePage = () => {
 
   return (
     <>
+      <TourController steps={noticeTourSteps} run={runTour} onClose={() => setRunTour(false)} />
+
       <Seo title="공지사항 | On & Off" description="On & Off에서 근태관리 서비스를 이용해보세요." />
+
       <div className="flex w-full flex-col gap-4 sm:py-2">
         <div className="flex max-w-7xl items-center justify-between px-4 sm:px-6">
-          <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center justify-between gap-3" data-tour="step-1">
             <Megaphone className="mb-1 h-6 w-6 text-white-text dark:text-dark-text" />
             <h2 className="text-lg font-bold text-white-text dark:text-dark-text">공지사항</h2>
             <span className="text-sm text-muted-foreground">총 {notices.length}개</span>
           </div>
+
           {userType === "manager" && (
-            <Button onClick={() => setIsModalOpen(true)} className="text-sm font-semibold">
+            <Button
+              data-tour="step-2"
+              onClick={() => setIsModalOpen(true)}
+              className="text-sm font-semibold"
+            >
               작성
             </Button>
           )}

--- a/src/store/tour.store.ts
+++ b/src/store/tour.store.ts
@@ -7,6 +7,7 @@ interface TourStoreState {
   clearSteps: () => void;
 }
 
+// 특정 페이지 투어 step 실행 여부 관리
 export const useTourStore = create<TourStoreState>(set => ({
   steps: [],
   setSteps: (steps: Step[]) => set({ steps }),

--- a/src/store/tour.store.ts
+++ b/src/store/tour.store.ts
@@ -3,13 +3,17 @@ import { Step } from "react-joyride";
 
 interface TourStoreState {
   steps: Step[];
+  run: boolean;
   setSteps: (steps: Step[]) => void;
+  setRun: (run: boolean) => void;
   clearSteps: () => void;
 }
 
 // 특정 페이지 투어 step 실행 여부 관리
 export const useTourStore = create<TourStoreState>(set => ({
   steps: [],
-  setSteps: (steps: Step[]) => set({ steps }),
-  clearSteps: () => set({ steps: [] }),
+  run: false,
+  setSteps: steps => set({ steps }),
+  setRun: run => set({ run }),
+  clearSteps: () => set({ steps: [], run: false }),
 }));

--- a/src/store/tour.store.ts
+++ b/src/store/tour.store.ts
@@ -1,0 +1,14 @@
+import { create } from "zustand";
+import { Step } from "react-joyride";
+
+interface TourStoreState {
+  steps: Step[];
+  setSteps: (steps: Step[]) => void;
+  clearSteps: () => void;
+}
+
+export const useTourStore = create<TourStoreState>(set => ({
+  steps: [],
+  setSteps: (steps: Step[]) => set({ steps }),
+  clearSteps: () => set({ steps: [] }),
+}));

--- a/src/util/tourStorage.util.ts
+++ b/src/util/tourStorage.util.ts
@@ -1,7 +1,9 @@
+// 계정 한정 특정 페이지의 처음 투어를 본 적이 있는지 확인하는 함수
 export const hasSeenTour = (pageKey: string, uid: string) => {
   return localStorage.getItem(`${pageKey}_tour_seen_${uid}`) === "true";
 };
 
+// 해당 페이지의 투어를 처음 봤을 때 호출
 export const markTourAsSeen = (pageKey: string, uid: string) => {
   localStorage.setItem(`${pageKey}_tour_seen_${uid}`, "true");
 };

--- a/src/util/tourStorage.util.ts
+++ b/src/util/tourStorage.util.ts
@@ -1,0 +1,7 @@
+export const hasSeenTour = (pageKey: string, uid: string) => {
+  return localStorage.getItem(`${pageKey}_tour_seen_${uid}`) === "true";
+};
+
+export const markTourAsSeen = (pageKey: string, uid: string) => {
+  localStorage.setItem(`${pageKey}_tour_seen_${uid}`, "true");
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #219 

## 📝작업 내용

> react-joyride 라이브러리 사용법

- managerTourStep.ts 파일 안에 투어 기능을 넣으려는 페이지 함수를 작성합니다.
```tsx
import { Step } from "react-joyride";

export const noticeTourSteps: Step[] = [
  {
    target: '[data-tour="step-1"]',
    content: "여기서 전체 공지사항 수를 확인할 수 있어요.",
    disableBeacon: true,
    placement: "bottom",
  },
  {
    target: '[data-tour="step-2"]',
    content: "새로운 공지사항을 작성할 수 있어요.",
    disableBeacon: true,
  },
];
```

- 메인 페이지에 useTour 커스텀 훅을 사용.
- 첫번째 인자 : pageKey (라벨)
- 두번째 인자 : step 함수 import
```tsx 
useTour("notice", noticeTourSteps);
```

> 투어 기능
- 계정 한정 첫 페이지에 들어왔을 때, 자동으로 투어 기능이 작동합니다.
- 그 이후로는 우측 하단에 있는 노란 버튼을 클릭하면 가이드가 열립니다.
- 투어 기능에 있는 버튼을 눌러야 다음 step으로 넘어갑니다. (모달 처럼 다른 부분을 클릭해도 넘어가는 현상을 수정)

<img width="1678" alt="스크린샷 2025-05-15 오후 6 26 41" src="https://github.com/user-attachments/assets/0ec4530e-792e-44ff-a8aa-55d097ed288c" />

## 💬리뷰 요구사항(선택)

- 스타일과 텍스트 관련한 건 고려하지 않았습니다. 테스트를 위해 오로지 기능적인 부분만 넣었기 때문에 감안하고 봐주시길 바라겠습니다. 추후 다른 페이지에 적용하면서 css를 만질 계획입니다.
