### PR TITLE
[#230] : employee joyride (비제어)

### DIFF
--- a/src/Components/common/CompanyInfo.tsx
+++ b/src/Components/common/CompanyInfo.tsx
@@ -11,7 +11,7 @@ interface ICompanyInfo {
 }
 const CompanyInfo = ({ companyLogo, companyName, companyIntro, className }: ICompanyInfo) => {
   return (
-    <Card className={twMerge("rounded-xl bg-white p-6 shadow-md", className)}>
+    <Card className={twMerge("rounded-xl bg-white p-6 shadow-md", className)} data-tour="guide-1">
       <div className="flex items-center gap-4">
         <Avatar className="h-16 w-16">
           <AvatarFallback>

--- a/src/Components/common/Header.tsx
+++ b/src/Components/common/Header.tsx
@@ -7,12 +7,31 @@ import AppTitle from "./AppTitle";
 import NotificationBell from "./NotificationBell";
 import { HelpCircle } from "lucide-react";
 import DarkmodeToggle from "./DarkmodeToggle";
+import { useTourStore } from "@/store/tour.store";
 
 interface HeaderProps {
   variant?: "employee" | "manager";
 }
 
 export default function Header({ variant = "manager" }: HeaderProps) {
+  const { setRun, setStepIndex } = useTourStore();
+
+  const handleStartTour = () => {
+    setRun(false);
+    setStepIndex(0);
+
+    setTimeout(() => {
+      const firstStep = useTourStore.getState().steps[0]?.target;
+      if (typeof firstStep === "string") {
+        const target = document.querySelector(firstStep);
+        if (target) {
+          target.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
+      }
+      setRun(true);
+    }, 200);
+  };
+
   if (variant === "manager") {
     return (
       <div className="fixed top-0 z-50 h-12 w-full border-b bg-dark-card-bg px-4 shadow-md dark:bg-dark-bg sm:h-14 md:h-16">
@@ -35,12 +54,7 @@ export default function Header({ variant = "manager" }: HeaderProps) {
       <div className="flex h-full w-full items-center justify-between">
         <AppTitle className="text-base text-white" />
         <div className="flex items-center gap-5">
-          {/* 추가 디자인 수정 필요 우선 header 에 넣어놓음 */}
-          <button
-            // onClick={() => setRunTour(true)}
-            className="rounded-full text-white"
-            aria-label="도움말"
-          >
+          <button onClick={handleStartTour} className="rounded-full text-white" aria-label="도움말">
             <HelpCircle className="h-5 w-5" />
           </button>
           <div className="flex items-center gap-3">

--- a/src/Components/common/TourController.tsx
+++ b/src/Components/common/TourController.tsx
@@ -53,13 +53,16 @@ const TourController = ({ steps, run, onClose, stepIndex, onStepChange }: TourCo
       callback={handleCallback}
       continuous
       scrollToFirstStep
-      showProgress
+      showProgress={false}
       showSkipButton
       disableOverlayClose
       disableScrolling
       spotlightClicks={false}
       hideCloseButton={true}
       spotlightPadding={10}
+      locale={{
+        last: "Done",
+      }}
       styles={{
         options: {
           zIndex: 10000,

--- a/src/Components/common/TourController.tsx
+++ b/src/Components/common/TourController.tsx
@@ -45,6 +45,9 @@ const TourController = ({ steps, run, onClose, stepIndex, onStepChange }: TourCo
 
   if (!run || steps.length === 0) return null;
 
+  const pathname = window.location.pathname;
+  const isEmployeePage = pathname.includes("/employee");
+
   return (
     <Joyride
       steps={steps}
@@ -52,11 +55,11 @@ const TourController = ({ steps, run, onClose, stepIndex, onStepChange }: TourCo
       stepIndex={controlled ? stepIndex : internalStepIndex}
       callback={handleCallback}
       continuous
-      scrollToFirstStep
+      scrollToFirstStep={false}
       showProgress={false}
       showSkipButton
-      disableOverlayClose
-      disableScrolling
+      disableOverlayClose={true}
+      disableScrolling={true}
       spotlightClicks={false}
       hideCloseButton={true}
       spotlightPadding={10}
@@ -65,8 +68,13 @@ const TourController = ({ steps, run, onClose, stepIndex, onStepChange }: TourCo
       }}
       styles={{
         options: {
-          zIndex: 10000,
           primaryColor: "#FFD369",
+          zIndex: 10000,
+          width: isEmployeePage ? 280 : 380,
+        },
+        tooltip: {
+          fontSize: isEmployeePage ? "14px" : "17px",
+          padding: "10px 14px",
         },
       }}
     />

--- a/src/Components/common/TourController.tsx
+++ b/src/Components/common/TourController.tsx
@@ -1,16 +1,45 @@
+import { useEffect, useState } from "react";
 import Joyride, { CallBackProps, STATUS, Step } from "react-joyride";
+import { useTourStore } from "@/store/tour.store";
 
 interface TourControllerProps {
   steps: Step[];
   run: boolean;
   onClose: () => void;
+  stepIndex?: number;
+  onStepChange?: (index: number) => void;
 }
 
-const TourController = ({ steps, run, onClose }: TourControllerProps) => {
+const TourController = ({ steps, run, onClose, stepIndex, onStepChange }: TourControllerProps) => {
+  const [internalStepIndex, setInternalStepIndex] = useState(0);
+  const controlled = typeof stepIndex === "number" && typeof onStepChange === "function";
+
+  const controlledSteps = useTourStore(state => state.controlledSteps);
+
+  useEffect(() => {
+    if (run && !controlled) setInternalStepIndex(0);
+  }, [run, controlled]);
+
   const handleCallback = (data: CallBackProps) => {
-    const { status } = data;
+    const { status, action, index, type } = data;
+
     if (status === STATUS.FINISHED || status === STATUS.SKIPPED) {
       onClose();
+      return;
+    }
+
+    const isControlled = controlledSteps.includes(index);
+
+    if (controlled && typeof onStepChange === "function") {
+      if (!isControlled && type === "step:after") {
+        if (action === "next") onStepChange(index + 1);
+        if (action === "prev") onStepChange(Math.max(index - 1, 0));
+      }
+    } else {
+      if (!isControlled && type === "step:after") {
+        if (action === "next") setInternalStepIndex(index + 1);
+        if (action === "prev") setInternalStepIndex(Math.max(index - 1, 0));
+      }
     }
   };
 
@@ -20,15 +49,17 @@ const TourController = ({ steps, run, onClose }: TourControllerProps) => {
     <Joyride
       steps={steps}
       run={run}
+      stepIndex={controlled ? stepIndex : internalStepIndex}
       callback={handleCallback}
       continuous
+      scrollToFirstStep
       showProgress
       showSkipButton
-      scrollToFirstStep
-      disableScrolling={true}
-      spotlightClicks={true}
-      disableOverlayClose={true}
+      disableOverlayClose
+      disableScrolling
+      spotlightClicks={false}
       hideCloseButton={true}
+      spotlightPadding={10}
       styles={{
         options: {
           zIndex: 10000,

--- a/src/Components/common/modal/NoticeModal.tsx
+++ b/src/Components/common/modal/NoticeModal.tsx
@@ -43,7 +43,7 @@ const NoticeModal = ({ onClose, onSave }: NoticeModalProps) => {
 
   return (
     <Dialog open onOpenChange={onClose}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-lg" data-tour="notice-modal">
         <DialogHeader>
           <DialogTitle>공지사항 작성</DialogTitle>
         </DialogHeader>

--- a/src/Components/company/notice/NoticeCard.tsx
+++ b/src/Components/company/notice/NoticeCard.tsx
@@ -13,7 +13,10 @@ interface NoticeCardProps {
 const NoticeCard = ({ title, content, createdAt, onDelete, noticeType }: NoticeCardProps) => {
   const [open, setOpen] = useState(false);
   return (
-    <div className="self-start rounded-md border border-white-border bg-white-card-bg p-5 shadow-md transition-all duration-200 dark:border-dark-border dark:bg-dark-card-bg">
+    <div
+      className="self-start rounded-md border border-white-border bg-white-card-bg p-5 shadow-md transition-all duration-200 dark:border-dark-border dark:bg-dark-card-bg"
+      data-tour="notice-2"
+    >
       <div className="flex items-start justify-between">
         <div className="flex items-center gap-2">
           {noticeType === "중요" && (
@@ -53,7 +56,6 @@ const NoticeCard = ({ title, content, createdAt, onDelete, noticeType }: NoticeC
           <button
             onClick={() => setOpen(prev => !prev)}
             className="text-[13px] underline underline-offset-2 hover:text-white-text dark:hover:text-dark-text"
-            data-tour="notice-2"
           >
             {open ? "간략히" : "자세히"}
           </button>

--- a/src/Components/employee/EmployeeMainContent.tsx
+++ b/src/Components/employee/EmployeeMainContent.tsx
@@ -10,8 +10,11 @@ import CommuteBox from "./mainpageBox/CommuteBox";
 import NoticeBox from "./mainpageBox/NoticeBox";
 import CommuteHistoryBox from "./mainpageBox/CommuteHistoryBox";
 import VacationBox from "./mainpageBox/VacationBox";
+import { useTour } from "@/hooks/use-tour";
+import { employeeHomeTourSteps } from "@/constants/employeeTourSteps";
 
 const EmployeeMainContent = () => {
+  useTour("employee_home", employeeHomeTourSteps);
   return (
     <div className="flex w-full flex-col gap-4 sm:py-5">
       {/* 서비스 이용 가이드 바로가기 */}

--- a/src/Components/employee/mainpageBox/CommuteBox.tsx
+++ b/src/Components/employee/mainpageBox/CommuteBox.tsx
@@ -21,7 +21,7 @@ const CommuteBox = () => {
   const { label, icon, colorClass } = getStatusDisplay(status);
 
   return (
-    <Card className="flex w-full flex-col justify-center p-6 shadow-md">
+    <Card className="flex w-full flex-col justify-center p-6 shadow-md" data-tour="home-2">
       {!isLoading && (
         <>
           <div className="mb-6 flex items-center justify-between">

--- a/src/Components/employee/mainpageBox/CommuteHistoryBox.tsx
+++ b/src/Components/employee/mainpageBox/CommuteHistoryBox.tsx
@@ -96,6 +96,7 @@ const CommuteHistoryBox = () => {
     <Card
       className="group relative cursor-pointer p-4 shadow-md transition hover:bg-muted/50"
       onClick={() => navigate(`/${companyCode}/employee/calendar`)}
+      data-tour="home-3"
     >
       {/* 헤더 */}
       <div className="flex items-center gap-2 text-base font-semibold">

--- a/src/Components/employee/mainpageBox/NoticeBox.tsx
+++ b/src/Components/employee/mainpageBox/NoticeBox.tsx
@@ -29,6 +29,7 @@ const NoticeBox = () => {
     <Card
       className="relative cursor-pointer p-4 shadow-md transition hover:bg-gray-50 dark:hover:bg-dark-card-bg"
       onClick={() => navigate(`/${companyCode}/employee/notice`)}
+      data-tour="home-1"
     >
       <ChevronRight className="absolute right-4 top-4 h-5 w-5 text-muted-foreground group-hover:text-foreground" />
       <CardTitle className="flex items-center gap-2 text-base">

--- a/src/Components/employee/mainpageBox/VacationBox.tsx
+++ b/src/Components/employee/mainpageBox/VacationBox.tsx
@@ -22,7 +22,7 @@ const VacationBox = () => {
   const { unreadVacationNotifications } = useNotification();
 
   return (
-    <Card className="group relative p-4 shadow-md transition hover:bg-accent">
+    <Card className="group relative p-4 shadow-md transition hover:bg-accent" data-tour="home-4">
       {/* 우측 이동 아이콘 */}
       <ChevronRight
         className="absolute right-4 top-4 h-5 w-5 cursor-pointer text-muted-foreground group-hover:text-foreground"

--- a/src/Components/employee/vacation/EmployeeVacationYearFilter.tsx
+++ b/src/Components/employee/vacation/EmployeeVacationYearFilter.tsx
@@ -30,7 +30,10 @@ const EmployeeVacationYearFilter = ({
     setCurrentPage(0);
   };
   return (
-    <Card className="relative cursor-pointer rounded-xl bg-vacation-color p-4 text-white shadow-md transition dark:bg-vacation-color">
+    <Card
+      className="relative cursor-pointer rounded-xl bg-vacation-color p-4 text-white shadow-md transition dark:bg-vacation-color"
+      data-tour="vacation-1"
+    >
       <div className="flex items-center justify-center">
         <div className="flex items-center gap-4">
           <Button

--- a/src/constants/employeeTourSteps.ts
+++ b/src/constants/employeeTourSteps.ts
@@ -1,0 +1,97 @@
+import { Step } from "react-joyride";
+
+export const employeeHomeTourSteps: Step[] = [
+  {
+    target: "body",
+    content: "직원의 간편한 출퇴근 처리 및 홈 대시보드입니다.",
+    placement: "center",
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="home-1"]',
+    content: "최신 공지사항을 확인하실 수 있습니다.",
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="home-2"]',
+    content: "버튼을 클릭하면 출퇴근이 가능합니다.",
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="home-3"]',
+    content: "최근 한 주의 출퇴근 현황을 보실 수 있습니다.",
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="home-4"]',
+    content: "최근 휴가 내역도 보실 수 있습니다.",
+    disableBeacon: true,
+  },
+];
+
+export const attRecordTourSteps: Step[] = [
+  {
+    target: "body",
+    content: "이곳은 출퇴근 기록 페이지입니다.",
+    placement: "center",
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="record-1"]',
+    content:
+      "자신의 출퇴근 기록을 달력으로 체크하실 수 있고 해당 날짜를 클릭하면 출퇴근 시간과 근무지를 알 수 있습니다.",
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="record-2"]',
+    content: "출퇴근 및 휴가의 월간 내역을 보실 수도 있습니다.",
+    disableBeacon: true,
+  },
+];
+
+export const vacationTourSteps: Step[] = [
+  {
+    target: "body",
+    content: "이곳은 휴가 페이지입니다.",
+    placement: "center",
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="vacation-1"]',
+    content: "연도별로 자신이 사용한 총 휴가 일수를 보실 수 있습니다.",
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="vacation-2"]',
+    content: "휴가를 요청하려면 버튼을 클릭해주세요!",
+    disableBeacon: true,
+  },
+  //   {
+  //     target: '[data-tour="vacation-modal"]',
+  //     content: "여기에 휴가 유형, 날짜, 사유를 적어 등록하시면 요청이 완료됩니다.",
+  //     disableBeacon: true,
+  //   },
+  {
+    target: '[data-tour="vacation-3"]',
+    content: "휴가를 요청한 상태 별로 보실 수 있으며 휴가 내역은 최신순으로 나열됩니다.",
+    disableBeacon: true,
+  },
+];
+export const empMenuTourSteps: Step[] = [
+  {
+    target: "body",
+    content: "이곳은 메뉴 페이지입니다.",
+    placement: "center",
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="guide-1"]',
+    content: "자신의 회사 정보를 볼 수 있습니다.",
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="guide-2"]',
+    content: "기타 메뉴들과 로그아웃 기능이 있습니다.",
+    disableBeacon: true,
+  },
+];

--- a/src/constants/managerTourSteps.ts
+++ b/src/constants/managerTourSteps.ts
@@ -9,7 +9,14 @@ export const noticeTourSteps: Step[] = [
   },
   {
     target: '[data-tour="notice-1"]',
-    content: "새로운 공지사항을 작성할 수 있어요.",
+    content: "새로운 공지사항을 작성할 수 있어요. 클릭해주세요!",
+    disableBeacon: true,
+    spotlightClicks: true,
+    hideFooter: true,
+  },
+  {
+    target: '[data-tour="notice-modal"]',
+    content: "게시물 유형을 설정하고 작성하면 공지가 업로드됩니다.",
     disableBeacon: true,
   },
   {

--- a/src/hooks/company-settings/useWorkplacePage.ts
+++ b/src/hooks/company-settings/useWorkplacePage.ts
@@ -24,6 +24,7 @@ export const useWorkplacePage = () => {
       });
       return;
     }
+
     const response = await updateCompanyWorkPlacesList(companyCode, data.companyWorkPlaces);
     if (response.success) {
       toast({

--- a/src/hooks/employee/useNearbyWorkplaces.ts
+++ b/src/hooks/employee/useNearbyWorkplaces.ts
@@ -1,27 +1,37 @@
-import { DISTANCE_THRESHOLD } from "@/constants/distance";
 import { TWorkPlace } from "@/model/types/company.type";
 import { getDistanceFromLatLng } from "@/util/latlng.util";
 import { useEffect, useState } from "react";
+import { useCompanyStore } from "@/store/company.store";
 
 export const useNearbyWorkplaces = (
   location: { lat: number; lng: number } | null,
   workPlaces: TWorkPlace[],
 ) => {
   const [nearby, setNearby] = useState<TWorkPlace[]>([]);
+  const { currentCompany } = useCompanyStore();
 
   useEffect(() => {
-    if (!location) return;
-    const placesWithDistance = workPlaces?.map(place => ({
-      ...place,
-      distance: getDistanceFromLatLng(location.lat, location.lng, place.lat, place.lng),
-    }));
+    if (!location || !currentCompany?.workPlacesList) return;
+
+    const placesWithDistance = workPlaces.map(place => {
+      const matched = currentCompany.workPlacesList.find(w => w.id === place.id);
+      const radius = matched?.radius ?? 0;
+
+      const distance = getDistanceFromLatLng(location.lat, location.lng, place.lat, place.lng);
+
+      return {
+        ...place,
+        radius,
+        distance,
+      };
+    });
 
     const filtered = placesWithDistance
-      ?.filter(p => p.distance <= DISTANCE_THRESHOLD)
-      ?.sort((a, b) => a.distance - b.distance);
+      .filter(p => p.distance <= p.radius)
+      .sort((a, b) => a.distance - b.distance);
 
     setNearby(filtered);
-  }, [workPlaces, location]);
+  }, [workPlaces, location, currentCompany]);
 
   return nearby;
 };

--- a/src/hooks/use-tour.ts
+++ b/src/hooks/use-tour.ts
@@ -1,34 +1,28 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { Step } from "react-joyride";
 import { useUserStore } from "@/store/user.store";
 import { useTourStore } from "@/store/tour.store";
 import { hasSeenTour, markTourAsSeen } from "@/util/tourStorage.util";
 
-export const useTour = (pageKey: string, steps: Step[], dependencyReady: boolean = true) => {
-  const [runTour, setRunTour] = useState(false);
+export const useTour = (
+  pageKey: string,
+  steps: Step[],
+  controlledSteps: number[] = [],
+  dependencyReady: boolean = true,
+) => {
   const userId = useUserStore(state => state.currentUser?.uid);
-  const setRun = useTourStore(state => state.setRun);
+  const { setSteps, setRun, setControlledSteps } = useTourStore.getState();
 
-  // steps 등록 (공통)
   useEffect(() => {
-    useTourStore.getState().setSteps(steps);
-  }, [steps]);
+    setSteps(steps);
+    setControlledSteps(controlledSteps);
+  }, [steps, controlledSteps]);
 
-  // 최초 페이지 진입 시 투어 실행
   useEffect(() => {
     if (!userId || !dependencyReady) return;
-
-    const hasSeen = hasSeenTour(pageKey, userId);
-    console.log(`[투어] hasSeen: ${hasSeen}, uid: ${userId}, pageKey: ${pageKey}`);
-    if (!hasSeen) {
-      console.log("[투어] 자동 실행 시작!");
-      setRun(true);
+    if (!hasSeenTour(pageKey, userId)) {
       markTourAsSeen(pageKey, userId);
+      setRun(true);
     }
   }, [userId, dependencyReady]);
-
-  return {
-    runTour,
-    setRunTour,
-  };
 };

--- a/src/layout/EmployeeLayout.tsx
+++ b/src/layout/EmployeeLayout.tsx
@@ -5,12 +5,18 @@ import MenuBar from "../components/common/menubar/MenuBar";
 import { Outlet } from "react-router-dom";
 import EmployeeEtcPageTitle from "@/components/employee/EmployeeEtcPageTitle";
 import { HelpCircle } from "lucide-react";
+import TourController from "@/components/common/TourController";
+import { useTourStore } from "@/store/tour.store";
 
 interface ILayoutProp {
   type: "main" | "sub"; // header, footer 안 보이는 서브 페이지 구분용
 }
 
 const EmployeeLayout = ({ type }: ILayoutProp) => {
+  const steps = useTourStore(state => state.steps);
+  const runTour = useTourStore(state => state.run);
+  const stepIndex = useTourStore(state => state.stepIndex);
+  const setStepIndex = useTourStore(state => state.setStepIndex);
   const isMain = type === "main";
 
   const mainClassName = isMain
@@ -18,16 +24,25 @@ const EmployeeLayout = ({ type }: ILayoutProp) => {
     : "flex flex-1 flex-col px-5 mt-10 py-8";
 
   return (
-    <div className="relative flex min-h-screen w-full justify-center bg-white-bg text-white-text">
-      <div className="relative flex w-full max-w-screen-sm flex-col dark:bg-dark-bg dark:text-dark-text">
-        {isMain ? <Header variant="employee" /> : <EmployeeEtcPageTitle />}
-        {isMain && <MenuBar />}
-        <main className={mainClassName}>
-          <Outlet />
-        </main>
-        {isMain && <Footer />}
+    <>
+      <TourController
+        steps={steps}
+        run={runTour}
+        onClose={() => useTourStore.getState().setRun(false)}
+        stepIndex={stepIndex}
+        onStepChange={setStepIndex}
+      />
+      <div className="relative flex min-h-screen w-full justify-center bg-white-bg text-white-text">
+        <div className="relative flex w-full max-w-screen-sm flex-col dark:bg-dark-bg dark:text-dark-text">
+          {isMain ? <Header variant="employee" /> : <EmployeeEtcPageTitle />}
+          {isMain && <MenuBar />}
+          <main className={mainClassName}>
+            <Outlet />
+          </main>
+          {isMain && <Footer />}
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/layout/ManagerLayout.tsx
+++ b/src/layout/ManagerLayout.tsx
@@ -1,4 +1,3 @@
-import React, { useState } from "react";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import MenuBar from "@/components/common/menubar/MenuBar";
 import Header from "@/components/common/Header";
@@ -11,22 +10,38 @@ const Layout = () => {
   const steps = useTourStore(state => state.steps);
   const runTour = useTourStore(state => state.run);
   const setRunTour = useTourStore(state => state.setRun);
+  const stepIndex = useTourStore(state => state.stepIndex);
+  const setStepIndex = useTourStore(state => state.setStepIndex);
 
   const handleStartTour = () => {
-    const target = document.querySelector('[data-tour="step-1"]');
+    const { setRun, setStepIndex } = useTourStore.getState();
 
-    if (target) {
-      target.scrollIntoView({ behavior: "smooth", block: "center" });
-    }
+    // 상태 초기화 (중요)
+    setRun(false);
+    setStepIndex(0);
 
     setTimeout(() => {
-      setRunTour(true);
-    }, 300);
+      const firstStep = useTourStore.getState().steps[0]?.target;
+      if (typeof firstStep === "string") {
+        const target = document.querySelector(firstStep);
+        if (target) {
+          target.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
+      }
+
+      setRun(true); // 반드시 마지막에 실행
+    }, 200);
   };
 
   return (
     <SidebarProvider>
-      <TourController steps={steps} run={runTour} onClose={() => setRunTour(false)} />
+      <TourController
+        steps={steps}
+        run={runTour}
+        onClose={() => setRunTour(false)}
+        stepIndex={stepIndex}
+        onStepChange={setStepIndex}
+      />
 
       <div className="relative flex min-h-screen w-screen bg-white-bg text-white-text dark:bg-dark-bg dark:text-dark-text">
         <MenuBar />

--- a/src/layout/ManagerLayout.tsx
+++ b/src/layout/ManagerLayout.tsx
@@ -9,15 +9,13 @@ import { useTourStore } from "@/store/tour.store";
 const Layout = () => {
   const steps = useTourStore(state => state.steps);
   const runTour = useTourStore(state => state.run);
-  const setRunTour = useTourStore(state => state.setRun);
   const stepIndex = useTourStore(state => state.stepIndex);
+  const setRunTour = useTourStore(state => state.setRun);
   const setStepIndex = useTourStore(state => state.setStepIndex);
 
   const handleStartTour = () => {
-    const { setRun, setStepIndex } = useTourStore.getState();
-
     // 상태 초기화 (중요)
-    setRun(false);
+    setRunTour(false);
     setStepIndex(0);
 
     setTimeout(() => {
@@ -29,7 +27,7 @@ const Layout = () => {
         }
       }
 
-      setRun(true); // 반드시 마지막에 실행
+      setRunTour(true); // 반드시 마지막에 실행
     }, 200);
   };
 

--- a/src/pages/employee/EmployeeMenuPage.tsx
+++ b/src/pages/employee/EmployeeMenuPage.tsx
@@ -7,6 +7,8 @@ import PoweredByFooter from "@/components/common/PoweredByFooter";
 import { useMenuBar } from "@/hooks/menu/useMenuBar";
 import Seo from "@/components/Seo";
 import { EMPLOYEE_SUB_MENUS } from "@/constants/menuConfig";
+import { useTour } from "@/hooks/use-tour";
+import { empMenuTourSteps } from "@/constants/employeeTourSteps";
 
 const EmployeeMenuPage = () => {
   const navigate = useNavigate();
@@ -25,6 +27,8 @@ const EmployeeMenuPage = () => {
     logout();
   };
 
+  useTour("employee-menu", empMenuTourSteps);
+
   return (
     <>
       <Seo title="메뉴 | On & Off" description="On & Off에서 근태관리 서비스를 이용해보세요." />
@@ -37,7 +41,10 @@ const EmployeeMenuPage = () => {
           className="shadow-sm"
         />
 
-        <div className="mt-4 flex flex-col divide-y rounded-md border bg-white shadow-sm dark:border-muted dark:bg-muted">
+        <div
+          className="mt-4 flex flex-col divide-y rounded-md border bg-white shadow-sm dark:border-muted dark:bg-muted"
+          data-tour="guide-2"
+        >
           {EMPLOYEE_SUB_MENUS(companyCode!).map((menu, idx) => (
             <div
               key={idx}

--- a/src/pages/employee/MyVacationPage.tsx
+++ b/src/pages/employee/MyVacationPage.tsx
@@ -15,6 +15,8 @@ import { IVacationRequest } from "@/components/company/table/VacationColumns";
 import VacationFilterButtons from "@/components/employee/vacation/EmployeeVacationTableFilterButton";
 import VacationListSection from "@/components/employee/vacation/EmployeeVacationListSection";
 import Seo from "@/components/Seo";
+import { useTour } from "@/hooks/use-tour";
+import { vacationTourSteps } from "@/constants/employeeTourSteps";
 
 const MyVacationPage = () => {
   const { companyCode } = useParams();
@@ -24,6 +26,8 @@ const MyVacationPage = () => {
   const [currentPage, setCurrentPage] = useState(0);
   const [filterStatus, setFilterStatus] = useState<"전체" | TVacationStatus>("전체");
   const [reloadKey, setReloadKey] = useState<number>(0);
+
+  useTour("vacation", vacationTourSteps);
 
   const year = date.getFullYear().toString();
   const { requests, loading, error } = useGetEmployeeVacationList({
@@ -76,11 +80,14 @@ const MyVacationPage = () => {
           yearFilteredRequests={yearOnlyApprovedRequests}
         />
 
-        <Button className="w-full cursor-pointer" onClick={toggleModal}>
+        <Button className="w-full cursor-pointer" onClick={toggleModal} data-tour="vacation-2">
           휴가 요청
         </Button>
 
-        <Card className="relative flex flex-col gap-5 p-4 shadow-md transition hover:bg-gray-50 dark:hover:bg-dark-card-bg">
+        <Card
+          className="relative flex flex-col gap-5 p-4 shadow-md transition hover:bg-gray-50 dark:hover:bg-dark-card-bg"
+          data-tour="vacation-3"
+        >
           <div className="flex items-center gap-2 text-base font-semibold">
             <PlaneTakeoff className="h-5 w-5 text-primary" />
             <CardTitle className="text-base">휴가 내역</CardTitle>

--- a/src/pages/employee/ShowCalendarPage.tsx
+++ b/src/pages/employee/ShowCalendarPage.tsx
@@ -1,6 +1,6 @@
 // import { useMatch } from "react-router-dom";
 import { useEffect, useState } from "react";
-import { useTour } from "@reactour/tour";
+import { useTour } from "@/hooks/use-tour";
 import { CALENDAR_STEPS } from "@/constants/tourStep";
 // import { useUserStore } from "@/store/user.store";
 import MyCalendar from "@/components/common/calendar/MyCalendar";
@@ -17,6 +17,7 @@ import {
 import Seo from "@/components/Seo";
 import { useShowCalendar } from "@/hooks/employee/useShowCalendar";
 import CommuteDetailModal from "@/components/common/modal/ShowCalendarDetailModal";
+import { attRecordTourSteps } from "@/constants/employeeTourSteps";
 
 const ShowCalendarPage = () => {
   const {
@@ -32,12 +33,14 @@ const ShowCalendarPage = () => {
     formatMinutesToHourText,
   } = useShowCalendar();
 
+  useTour("attendace-record", attRecordTourSteps);
+
   return (
     <>
       <Seo title="출퇴근 | On & Off" description="On & Off에서 근태관리 서비스를 이용해보세요." />
       <div className="flex w-full flex-col items-center">
         {/* 캘린더 */}
-        <Card className="m-4 w-full shadow-md">
+        <Card className="m-4 w-full shadow-md" data-tour="record-1">
           <CardContent className="p-8">
             <MyCalendar
               data={commuteData}
@@ -63,7 +66,7 @@ const ShowCalendarPage = () => {
           </div>
         </div>
 
-        <div className="max-w2xl mb-4 w-full">
+        <div className="max-w2xl mb-4 w-full" data-tour="record-2">
           <Table className="w-full">
             <TableHeader>
               <TableRow className="border-b border-solid border-white-border dark:border-dark-border">

--- a/src/pages/manager/NoticePage.tsx
+++ b/src/pages/manager/NoticePage.tsx
@@ -44,10 +44,6 @@ const NoticePage = () => {
   const handleCloseModal = () => {
     setIsModalOpen(false);
 
-    // body에 Dialog가 추가한 스타일 제거
-    document.body.classList.remove("overflow-hidden");
-    document.body.style.removeProperty("padding-right");
-
     // 모달 투어 스텝 처리 (현재 notice-2가 열린 상태라면 다음 스텝으로)
     const currentStep = steps[stepIndex];
     if (run && currentStep?.target === '[data-tour="notice-modal"]') {

--- a/src/pages/manager/NoticePage.tsx
+++ b/src/pages/manager/NoticePage.tsx
@@ -11,6 +11,7 @@ import { ChevronUp, Megaphone } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { noticeTourSteps } from "@/constants/managerTourSteps";
 import { useTour } from "@/hooks/use-tour";
+import { useTourStore } from "@/store/tour.store";
 
 const NoticePage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -19,9 +20,42 @@ const NoticePage = () => {
   const companyCode = useUserStore(state => state.currentUser?.companyCode);
   const { toast } = useToast();
 
-  // 투어관련 커스텀 훅
-  console.log("[투어] useTour 호출됨");
-  useTour("notice", noticeTourSteps);
+  useTour("notice", noticeTourSteps, [1]);
+
+  const run = useTourStore(state => state.run);
+  const steps = useTourStore(state => state.steps);
+  const stepIndex = useTourStore(state => state.stepIndex);
+  const setStepIndex = useTourStore(state => state.setStepIndex);
+
+  const handleClickWriteButton = () => {
+    setIsModalOpen(true);
+
+    const currentStep = steps[stepIndex];
+    if (run && currentStep?.target === '[data-tour="notice-1"]') {
+      setTimeout(() => {
+        const target = document.querySelector('[data-tour="notice-2"]');
+        if (target) {
+          setStepIndex(stepIndex + 1);
+        }
+      }, 300);
+    }
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+
+    // body에 Dialog가 추가한 스타일 제거
+    document.body.classList.remove("overflow-hidden");
+    document.body.style.removeProperty("padding-right");
+
+    // 모달 투어 스텝 처리 (현재 notice-2가 열린 상태라면 다음 스텝으로)
+    const currentStep = steps[stepIndex];
+    if (run && currentStep?.target === '[data-tour="notice-modal"]') {
+      setTimeout(() => {
+        setStepIndex(stepIndex + 1);
+      }, 300);
+    }
+  };
 
   const [page, setPage] = useState(1);
   const noticesPerPage = 6;
@@ -87,7 +121,7 @@ const NoticePage = () => {
           {userType === "manager" && (
             <Button
               data-tour="notice-1"
-              onClick={() => setIsModalOpen(true)}
+              onClick={handleClickWriteButton}
               className="text-sm font-semibold"
             >
               작성
@@ -121,7 +155,10 @@ const NoticePage = () => {
       )}
 
       {isModalOpen && (
-        <NoticeModal onClose={() => setIsModalOpen(false)} onSave={handleSaveNotice} />
+        <NoticeModal
+          onClose={handleCloseModal} // 기존 onClose에 handleCloseModal 연결
+          onSave={handleSaveNotice}
+        />
       )}
     </>
   );

--- a/src/store/tour.store.ts
+++ b/src/store/tour.store.ts
@@ -4,16 +4,23 @@ import { Step } from "react-joyride";
 interface TourStoreState {
   steps: Step[];
   run: boolean;
+  stepIndex: number;
+  controlledSteps: number[];
   setSteps: (steps: Step[]) => void;
   setRun: (run: boolean) => void;
+  setStepIndex: (index: number) => void;
+  setControlledSteps: (steps: number[]) => void;
   clearSteps: () => void;
 }
 
-// 특정 페이지 투어 step 실행 여부 관리
 export const useTourStore = create<TourStoreState>(set => ({
   steps: [],
   run: false,
+  stepIndex: 0,
+  controlledSteps: [],
   setSteps: steps => set({ steps }),
   setRun: run => set({ run }),
-  clearSteps: () => set({ steps: [], run: false }),
+  setStepIndex: index => set({ stepIndex: index }),
+  setControlledSteps: steps => set({ controlledSteps: steps }),
+  clearSteps: () => set({ steps: [], run: false, stepIndex: 0, controlledSteps: [] }),
 }));


### PR DESCRIPTION
## #️⃣연관된 이슈

> #230 

## 📝작업 내용

> 직원 페이지 joyride 적용 (비제어)
- 기존 PC(관리자) 투어에 대비해서 모바일은 전용으로 텍스트의 크기와 너비를 조정했습니다.
<img width="260" alt="스크린샷 2025-05-26 오후 7 01 51" src="https://github.com/user-attachments/assets/fb00b878-6bb0-4df8-a0a1-f19abde8ef52" />
<img width="260" alt="스크린샷 2025-05-26 오후 7 02 01" src="https://github.com/user-attachments/assets/061b5ad8-dec2-4361-9993-743f62b8f37d" />
<img width="260" alt="스크린샷 2025-05-26 오후 7 02 11" src="https://github.com/user-attachments/assets/14683268-81ef-4e5d-9c32-e9716f9f2648" />

> 근무지 반경 설정 데이터 반영
- 기존에는 현재 위치와 고정 상수값을 비교하여 출퇴근을 할 때, 내가 실제로 근무지 안에 위치해 있는지를 판단하기 어려웠음.

```tsx
useEffect(() => {
    if (!location) return;
    const placesWithDistance = workPlaces?.map(place => ({
      ...place,
      distance: getDistanceFromLatLng(location.lat, location.lng, place.lat, place.lng),
    }));

    const filtered = placesWithDistance
      ?.filter(p => p.distance <= DISTANCE_THRESHOLD)
      ?.sort((a, b) => a.distance - b.distance);

    setNearby(filtered);
  }, [workPlaces, location]);
```

- 고정 상수값을 제거하고 스토어에 있는 radius를 가져와서 실제 현재 위치와 근무지 반경의 거리 계산으로 출퇴근 여부를 판단이 가능해짐.

```tsx
useEffect(() => {
    if (!location || !currentCompany?.workPlacesList) return;

    const placesWithDistance = workPlaces.map(place => {
      const matched = currentCompany.workPlacesList.find(w => w.id === place.id);
      const radius = matched?.radius ?? 0;

      const distance = getDistanceFromLatLng(location.lat, location.lng, place.lat, place.lng);

      return {
        ...place,
        radius,
        distance,
      };
    });

    const filtered = placesWithDistance
      .filter(p => p.distance <= p.radius)
      .sort((a, b) => a.distance - b.distance);

    setNearby(filtered);
  }, [workPlaces, location, currentCompany]);
```

- 테스트 해본 결과, 나의 현재 위치가 중학교 근처라고 가정했을 때, 반경 안에 들지 못하므로 근무지가 나오면 안됨. 하지만 고정 상수값 때문 그대로 출퇴근이 가능해지는 결과가 초래함.
<img width="380" alt="스크린샷 2025-05-26 오후 8 47 30" src="https://github.com/user-attachments/assets/9618e2f5-0f60-41e2-b4d0-0bb4ab1ecc16" /><br/><br/>

- 하지만 radius값을 가져오니 정상적으로 현위치가 근무지 반경에 들지 않으므로 근무지가 나오지 않음.

<img width="377" alt="스크린샷 2025-05-26 오후 8 50 02" src="https://github.com/user-attachments/assets/f6ceda16-2bfb-4ec2-973e-919855242d3d" /><br/><br/>

- 현위치를 근무지 반경안에 설정했을 때, 정상적으로 근무지가 나옴.

<img width="381" alt="스크린샷 2025-05-26 오후 8 52 48" src="https://github.com/user-attachments/assets/4ec2afbe-d59e-4521-876d-5af99a794321" />


## 💬리뷰 요구사항(선택)

- 현재 joyride 제어방식 (클릭 시, 모달이나 이동한 페이지에 대한 투어 스텝) 관련해서 관리자 공지사항 페이지 부분은 구현했으나, 다른 페이지에도 적용하려니 컴포넌트마다 각기 다른 코드가 있어 같은 방식으로 적용하면 제대로 작동하지 않는 이슈로 리팩토링때 구현 예정입니다.
- 투어 기능 중 스텝이 나오면 화면이 제멋대로 이동되는 현상을 수정하려 했으나, 돌파구를 찾지 못했습니다.
