### PR TITLE
[#234] : 직원 페이지 최종 QA (모달 관련 X)

### DIFF
--- a/src/Components/common/CompanySummaryInfo.tsx
+++ b/src/Components/common/CompanySummaryInfo.tsx
@@ -31,9 +31,9 @@ const CompanySummaryInfo = ({ type = "manager", className }: ICompanySummaryInfo
       <div className="flex flex-col text-sm text-white-text">
         {type === "employee" ? (
           <>
-            <span className="text-base font-bold">{name}</span>
+            <span className="text-base font-bold">{companyName}</span>
             <span className="max-w-[160px] truncate text-xs text-gray-700">
-              <span className="font-bold">{companyName}</span> ・ {jobName} ・ {workType}
+              <span className="font-bold">{name}</span> ・ {jobName} ・ {workType}
             </span>
           </>
         ) : (

--- a/src/Components/common/CompanySummaryInfo.tsx
+++ b/src/Components/common/CompanySummaryInfo.tsx
@@ -33,7 +33,7 @@ const CompanySummaryInfo = ({ type = "manager", className }: ICompanySummaryInfo
           <>
             <span className="text-base font-bold">{name}</span>
             <span className="max-w-[160px] truncate text-xs text-gray-700">
-              {jobName} ・ {workType} ・ {companyName}
+              <span className="font-bold">{companyName}</span> ・ {jobName} ・ {workType}
             </span>
           </>
         ) : (

--- a/src/Components/common/CompanySummaryInfo.tsx
+++ b/src/Components/common/CompanySummaryInfo.tsx
@@ -29,11 +29,19 @@ const CompanySummaryInfo = ({ type = "manager", className }: ICompanySummaryInfo
       </Avatar>
 
       <div className="flex flex-col text-sm text-white-text">
-        <span className="max-w-[160px] truncate text-base font-bold">{companyName}</span>
-
-        <span className="text-xs text-gray-700">
-          {name} ・ {type === "manager" ? "관리자" : `${jobName} ・ ${workType}`}
-        </span>
+        {type === "employee" ? (
+          <>
+            <span className="text-base font-bold">{name}</span>
+            <span className="max-w-[160px] truncate text-xs text-gray-700">
+              {jobName} ・ {workType} ・ {companyName}
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="max-w-[160px] truncate text-base font-bold">{companyName}</span>
+            <span className="text-xs text-gray-700">{name} ・ 관리자</span>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/Components/company/notice/NoticeCard.tsx
+++ b/src/Components/company/notice/NoticeCard.tsx
@@ -1,20 +1,26 @@
-import { useState } from "react";
 import { X } from "lucide-react";
-import { format, parseISO } from "date-fns";
 
 interface NoticeCardProps {
   title: string;
   content: string;
   createdAt: string;
   onDelete?: () => void;
+  onClick?: () => void;
   noticeType?: "중요" | "일반";
 }
 
-const NoticeCard = ({ title, content, createdAt, onDelete, noticeType }: NoticeCardProps) => {
-  const [open, setOpen] = useState(false);
+const NoticeCard = ({
+  title,
+  content,
+  createdAt,
+  onDelete,
+  onClick,
+  noticeType,
+}: NoticeCardProps) => {
   return (
     <div
-      className="self-start rounded-md border border-white-border bg-white-card-bg p-5 shadow-md transition-all duration-200 dark:border-dark-border dark:bg-dark-card-bg"
+      onClick={onClick}
+      className="cursor-pointer self-start rounded-md border border-white-border bg-white-card-bg p-5 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl dark:border-dark-border dark:bg-dark-card-bg"
       data-tour="notice-2"
     >
       <div className="flex items-start justify-between">
@@ -27,7 +33,10 @@ const NoticeCard = ({ title, content, createdAt, onDelete, noticeType }: NoticeC
 
         {onDelete && (
           <button
-            onClick={onDelete}
+            onClick={e => {
+              e.stopPropagation();
+              onDelete();
+            }}
             className="text-muted-foreground hover:text-destructive"
             aria-label="삭제"
           >
@@ -36,30 +45,15 @@ const NoticeCard = ({ title, content, createdAt, onDelete, noticeType }: NoticeC
         )}
       </div>
 
-      <div
-        className={`my-4 cursor-pointer overflow-hidden text-sm text-muted-foreground transition-all duration-500 ease-in-out ${
-          open ? "max-h-[500px]" : "max-h-[24px]"
-        }`}
-        onClick={() => setOpen(prev => !prev)}
+      <p
+        className="my-4 line-clamp-1 pr-5 text-sm text-muted-foreground"
+        style={{ whiteSpace: "pre-line" }}
       >
-        <p
-          className={`${!open ? "line-clamp-1" : ""}`}
-          style={{ whiteSpace: "pre-line" }} //
-        >
-          {content}
-        </p>
-      </div>
+        {content}
+      </p>
 
-      <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
+      <div className="mt-2 flex items-center text-xs text-muted-foreground">
         <span>{createdAt?.split("T")[0] ?? "-"}</span>
-        {content.length > 40 && (
-          <button
-            onClick={() => setOpen(prev => !prev)}
-            className="text-[13px] underline underline-offset-2 hover:text-white-text dark:hover:text-dark-text"
-          >
-            {open ? "간략히" : "자세히"}
-          </button>
-        )}
       </div>
     </div>
   );

--- a/src/Components/company/notice/NoticeDetailModal.tsx
+++ b/src/Components/company/notice/NoticeDetailModal.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
+import { TNotice } from "@/model/types/manager.type";
+
+interface NoticeModalProps {
+  onClose: () => void;
+  onSave?: (notice: TNotice) => void;
+  notice?: TNotice;
+  readOnly?: boolean;
+}
+
+const NoticeModal = ({ onClose, onSave, notice, readOnly = false }: NoticeModalProps) => {
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+
+  useEffect(() => {
+    if (notice) {
+      setTitle(notice.title);
+      setContent(notice.content);
+    }
+  }, [notice]);
+
+  const handleSave = () => {
+    if (!title || !content || !onSave) return;
+    const newNotice: TNotice = {
+      ...notice,
+      title,
+      content,
+      createdAt: new Date().toISOString(),
+      noticeType: "일반", // or "중요"
+      id: notice?.id ?? `${Date.now()}`,
+    };
+    onSave(newNotice);
+  };
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="w-full max-w-md rounded-md">
+        <DialogHeader>
+          <DialogTitle className="text-lg font-bold">
+            {readOnly ? "공지사항 상세" : "공지사항 작성"}
+          </DialogTitle>
+        </DialogHeader>
+
+        {readOnly ? (
+          <div className="flex flex-col gap-4 py-2 text-sm text-muted-foreground">
+            <div>
+              <p className="mb-1 font-semibold text-white-text dark:text-dark-text">제목</p>
+              <p className="whitespace-pre-line">{title}</p>
+            </div>
+            <div>
+              <p className="mb-1 font-semibold text-white-text dark:text-dark-text">내용</p>
+              <p className="whitespace-pre-line">{content}</p>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4 py-2">
+            <Input
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              placeholder="제목을 입력하세요"
+            />
+            <Textarea
+              value={content}
+              onChange={e => setContent(e.target.value)}
+              placeholder="내용을 입력하세요"
+              rows={8}
+            />
+          </div>
+        )}
+
+        {!readOnly && (
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={onClose}>
+              취소
+            </Button>
+            <Button onClick={handleSave}>저장</Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default NoticeModal;

--- a/src/Components/employee/mainpageBox/VacationBox.tsx
+++ b/src/Components/employee/mainpageBox/VacationBox.tsx
@@ -22,7 +22,7 @@ const VacationBox = () => {
   const { unreadVacationNotifications } = useNotification();
 
   return (
-    <Card className="group relative p-4 shadow-md transition hover:bg-accent" data-tour="home-4">
+    <Card className="group relative p-4 shadow-md transition" data-tour="home-4">
       {/* 우측 이동 아이콘 */}
       <ChevronRight
         className="absolute right-4 top-4 h-5 w-5 cursor-pointer text-muted-foreground group-hover:text-foreground"

--- a/src/Components/employee/vacation/EmployeeVacationItem.tsx
+++ b/src/Components/employee/vacation/EmployeeVacationItem.tsx
@@ -25,7 +25,7 @@ const EmployeeVacationItem = ({ request, label, start, end, isSameDay }: Props) 
   return (
     <>
       <div
-        className="group flex cursor-pointer flex-col gap-2 rounded-lg border bg-white p-4 shadow-sm transition hover:bg-accent dark:border-gray-700 dark:bg-dark-card-bg"
+        className="group flex flex-col gap-2 rounded-lg border bg-white p-4 shadow-sm transition dark:border-gray-700 dark:bg-dark-card-bg"
         onClick={e => {
           e.stopPropagation();
           setModalOpen(true);

--- a/src/Components/ui/notificationDropdown.tsx
+++ b/src/Components/ui/notificationDropdown.tsx
@@ -62,7 +62,7 @@ const NotificationDropdown = ({
             .map(({ id, data }) => (
               <li
                 key={id}
-                className="dark:hover:bg-dark-hover group flex flex-col rounded-md px-2 py-3 text-sm hover:bg-white-hover"
+                className="dark:hover:bg-dark-hover group flex flex-col rounded-md px-2 py-4 text-sm hover:bg-white-hover"
               >
                 <div className="flex items-center justify-between gap-2">
                   <div

--- a/src/pages/employee/ShowCalendarPage.tsx
+++ b/src/pages/employee/ShowCalendarPage.tsx
@@ -18,6 +18,7 @@ import Seo from "@/components/Seo";
 import { useShowCalendar } from "@/hooks/employee/useShowCalendar";
 import CommuteDetailModal from "@/components/common/modal/ShowCalendarDetailModal";
 import { attRecordTourSteps } from "@/constants/employeeTourSteps";
+import { Briefcase, LogIn, PlaneTakeoff } from "lucide-react";
 
 const ShowCalendarPage = () => {
   const {
@@ -57,45 +58,53 @@ const ShowCalendarPage = () => {
             <span className="text-sm">출근</span>
           </div>
           <div className="flex items-center gap-1">
-            <div className="h-3 w-3 rounded-full bg-blue-500" />
-            <span className="text-sm">휴가</span>
-          </div>
-          <div className="flex items-center gap-1">
             <div className="h-3 w-3 rounded-full bg-yellow-500" />
             <span className="text-sm">외근</span>
           </div>
+          <div className="flex items-center gap-1">
+            <div className="h-3 w-3 rounded-full bg-blue-500" />
+            <span className="text-sm">휴가</span>
+          </div>
         </div>
 
-        <div className="max-w2xl mb-4 w-full" data-tour="record-2">
-          <Table className="w-full">
-            <TableHeader>
-              <TableRow className="border-b border-solid border-white-border dark:border-dark-border">
-                <TableHead>WORK</TableHead>
-                <TableHead>COUNT</TableHead>
-                <TableHead>TIME</TableHead>
-              </TableRow>
-            </TableHeader>
-            {summary && (
-              <TableBody>
-                <TableRow className="border-b border-solid border-white-border-sub dark:border-dark-border-sub">
-                  <TableCell>출근</TableCell>
-                  <TableCell>{summary.work.count} 일</TableCell>
-                  <TableCell>{formatMinutesToHourText(summary.work.time)}</TableCell>
-                </TableRow>
-                <TableRow className="border-b border-solid border-white-border-sub dark:border-dark-border-sub">
-                  <TableCell>외근</TableCell>
-                  <TableCell>{summary.out.count} 일</TableCell>
-                  <TableCell>{formatMinutesToHourText(summary.out.time)}</TableCell>
-                </TableRow>
-                <TableRow className="border-b border-solid border-white-border-sub dark:border-dark-border-sub">
-                  <TableCell>휴가</TableCell>
-                  <TableCell>{summary.vacation.count} 일</TableCell>
-                  <TableCell>-</TableCell>
-                </TableRow>
-              </TableBody>
-            )}
-          </Table>
-        </div>
+        {summary && (
+          <div className="mt-4 flex w-full flex-col gap-3" data-tour="record-2">
+            <div className="flex items-center justify-between rounded-md bg-green-100 px-4 py-5 shadow-md dark:bg-green-950">
+              <div className="flex items-center gap-2 text-green-800 dark:text-green-100">
+                <LogIn className="h-4 w-4" />
+                <span className="text-base font-medium">출근</span>
+              </div>
+              <div className="flex gap-3">
+                <span className="rounded-md bg-white/60 px-3 py-1 text-base font-bold text-green-800">
+                  {formatMinutesToHourText(summary.work.time)}
+                </span>
+                <span className="rounded-md bg-white/60 px-3 py-1 text-base font-bold text-green-800">
+                  {summary.work.count}일
+                </span>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between rounded-md bg-orange-100 px-4 py-5 shadow-md dark:bg-yellow-950">
+              <div className="flex items-center gap-2 text-orange-800 dark:text-orange-100">
+                <Briefcase className="h-4 w-4" />
+                <span className="text-base font-medium">외근</span>
+              </div>
+              <span className="rounded-md bg-white/60 px-3 py-1 text-base font-bold text-orange-800">
+                {summary.out.count}일
+              </span>
+            </div>
+
+            <div className="flex items-center justify-between rounded-md bg-blue-100 px-4 py-5 shadow-md dark:bg-blue-950">
+              <div className="flex items-center gap-2 text-blue-800 dark:text-blue-100">
+                <PlaneTakeoff className="h-4 w-4" />
+                <span className="text-base font-medium">휴가</span>
+              </div>
+              <span className="rounded-md bg-white/60 px-3 py-1 text-base font-bold text-blue-800">
+                {summary.vacation.count}일
+              </span>
+            </div>
+          </div>
+        )}
 
         <CommuteDetailModal
           open={openModal}

--- a/src/pages/employee/ShowCalendarPage.tsx
+++ b/src/pages/employee/ShowCalendarPage.tsx
@@ -70,36 +70,36 @@ const ShowCalendarPage = () => {
         {summary && (
           <div className="mt-4 flex w-full flex-col gap-3" data-tour="record-2">
             <div className="flex items-center justify-between rounded-md bg-green-100 px-4 py-5 shadow-md dark:bg-green-950">
-              <div className="flex items-center gap-2 text-green-800 dark:text-green-100">
+              <div className="flex items-center gap-2 text-green-800 dark:text-green-200">
                 <LogIn className="h-4 w-4" />
                 <span className="text-base font-medium">출근</span>
               </div>
               <div className="flex gap-3">
-                <span className="rounded-md bg-white/60 px-3 py-1 text-base font-bold text-green-800">
+                <span className="rounded-md bg-white/60 px-3 py-1 text-base font-bold text-green-800 dark:bg-black/30 dark:text-green-200">
                   {formatMinutesToHourText(summary.work.time)}
                 </span>
-                <span className="rounded-md bg-white/60 px-3 py-1 text-base font-bold text-green-800">
+                <span className="rounded-md bg-white/60 px-3 py-1 text-base font-bold text-green-800 dark:bg-black/30 dark:text-green-200">
                   {summary.work.count}일
                 </span>
               </div>
             </div>
 
             <div className="flex items-center justify-between rounded-md bg-orange-100 px-4 py-5 shadow-md dark:bg-yellow-950">
-              <div className="flex items-center gap-2 text-orange-800 dark:text-orange-100">
+              <div className="flex items-center gap-2 text-orange-800 dark:text-orange-200">
                 <Briefcase className="h-4 w-4" />
                 <span className="text-base font-medium">외근</span>
               </div>
-              <span className="rounded-md bg-white/60 px-3 py-1 text-base font-bold text-orange-800">
+              <span className="rounded-md bg-white/60 px-3 py-1 text-base font-bold text-orange-800 dark:bg-black/30 dark:text-orange-200">
                 {summary.out.count}일
               </span>
             </div>
 
             <div className="flex items-center justify-between rounded-md bg-blue-100 px-4 py-5 shadow-md dark:bg-blue-950">
-              <div className="flex items-center gap-2 text-blue-800 dark:text-blue-100">
+              <div className="flex items-center gap-2 text-blue-800 dark:text-blue-200">
                 <PlaneTakeoff className="h-4 w-4" />
                 <span className="text-base font-medium">휴가</span>
               </div>
-              <span className="rounded-md bg-white/60 px-3 py-1 text-base font-bold text-blue-800">
+              <span className="rounded-md bg-white/60 px-3 py-1 text-base font-bold text-blue-800 dark:bg-black/30 dark:text-blue-200">
                 {summary.vacation.count}일
               </span>
             </div>

--- a/src/pages/manager/NoticePage.tsx
+++ b/src/pages/manager/NoticePage.tsx
@@ -7,14 +7,16 @@ import { TNotice } from "@/model/types/manager.type";
 import { useNotice } from "@/hooks/manager/useNotice";
 import { useUserStore } from "@/store/user.store";
 import { deleteNotice } from "@/api/notice.api";
-import { ChevronUp, Megaphone } from "lucide-react";
+import { ChevronUp } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { noticeTourSteps } from "@/constants/managerTourSteps";
 import { useTour } from "@/hooks/use-tour";
 import { useTourStore } from "@/store/tour.store";
+import NoticeDetailModal from "@/components/company/notice/NoticeDetailModal";
 
 const NoticePage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedNotice, setSelectedNotice] = useState<TNotice | null>(null);
   const { notices, addNotice } = useNotice();
   const userType = useUserStore(state => state.currentUser?.userType);
   const companyCode = useUserStore(state => state.currentUser?.companyCode);
@@ -44,7 +46,6 @@ const NoticePage = () => {
   const handleCloseModal = () => {
     setIsModalOpen(false);
 
-    // 모달 투어 스텝 처리 (현재 notice-2가 열린 상태라면 다음 스텝으로)
     const currentStep = steps[stepIndex];
     if (run && currentStep?.target === '[data-tour="notice-modal"]') {
       setTimeout(() => {
@@ -107,13 +108,7 @@ const NoticePage = () => {
       <Seo title="공지사항 | On & Off" description="On & Off에서 근태관리 서비스를 이용해보세요." />
 
       <div className="flex w-full flex-col gap-4 sm:py-2">
-        <div className="flex max-w-7xl items-center justify-between px-4 sm:px-6">
-          <div className="flex items-center justify-between gap-3">
-            <Megaphone className="mb-1 h-6 w-6 text-white-text dark:text-dark-text" />
-            <h2 className="text-lg font-bold text-white-text dark:text-dark-text">공지사항</h2>
-            <span className="text-sm text-muted-foreground">총 {notices.length}개</span>
-          </div>
-
+        <div className="flex max-w-7xl items-center justify-end px-4 sm:px-6">
           {userType === "manager" && (
             <Button
               data-tour="notice-1"
@@ -129,9 +124,14 @@ const NoticePage = () => {
           {sortedNotices.length === 0 ? (
             <p className="text-sm text-muted-foreground">등록된 공지사항이 없습니다.</p>
           ) : (
-            sortedNotices.map((notice, idx) =>
+            sortedNotices.map(notice =>
               notice.id ? (
-                <NoticeCard key={notice.id} {...notice} onDelete={() => handleDelete(notice.id!)} />
+                <NoticeCard
+                  key={notice.id}
+                  {...notice}
+                  onClick={() => setSelectedNotice(notice)}
+                  onDelete={userType === "manager" ? () => handleDelete(notice.id!) : undefined}
+                />
               ) : null,
             )
           )}
@@ -150,10 +150,13 @@ const NoticePage = () => {
         </div>
       )}
 
-      {isModalOpen && (
-        <NoticeModal
-          onClose={handleCloseModal} // 기존 onClose에 handleCloseModal 연결
-          onSave={handleSaveNotice}
+      {isModalOpen && <NoticeModal onClose={handleCloseModal} onSave={handleSaveNotice} />}
+
+      {selectedNotice && (
+        <NoticeDetailModal
+          notice={selectedNotice}
+          onClose={() => setSelectedNotice(null)}
+          readOnly
         />
       )}
     </>

--- a/src/pages/manager/NoticePage.tsx
+++ b/src/pages/manager/NoticePage.tsx
@@ -108,7 +108,8 @@ const NoticePage = () => {
       <Seo title="공지사항 | On & Off" description="On & Off에서 근태관리 서비스를 이용해보세요." />
 
       <div className="flex w-full flex-col gap-4 sm:py-2">
-        <div className="flex max-w-7xl items-center justify-end px-4 sm:px-6">
+        <div className="flex max-w-7xl items-center justify-between px-4 sm:px-6">
+          {/* <p className="text-sm">※ 자세한 공지 내용은 박스를 클릭해주세요.</p> */}
           {userType === "manager" && (
             <Button
               data-tour="notice-1"


### PR DESCRIPTION
## #️⃣연관된 이슈

> #234 

## 📝작업 내용

> 공지사항 관련
- 게시물 삭제 권한 미부여 및 기존 페이지 타이틀 제거. (관리자 페이지에서도 제거함.)
- 공지사항 상세 게시물을 모달로 변경하였으며, 통합 모달 컴포넌트로 통해 교체할 예정입니다.
<img width="340" alt="스크린샷 2025-05-27 오후 8 48 30" src="https://github.com/user-attachments/assets/3cea93e5-c6c1-4e28-a9dc-66bf8a1200e9" />
<img width="340" alt="스크린샷 2025-05-27 오후 8 50 13" src="https://github.com/user-attachments/assets/08f138f2-32ac-482c-a547-74c799c02455" />

> 출퇴근 기록 페이지 (통계)
- 기존 표 형태의 UI에서 대시보드 형태로 변경
<img width="381" alt="스크린샷 2025-05-27 오후 8 53 26" src="https://github.com/user-attachments/assets/12eee895-af93-46f7-ad6d-8fd40afcaef8" />

> 추가 pr
- 직원 홈 휴가 박스가 호버가 되어 클릭 시, 페이지 이동되는 걸 화살표로 이동하게끔만 하도록 수정 (호버 제거)


## 💬리뷰 요구사항(선택)

- 모달 관련 작업은 다른 브랜치에서 한번에 작업하겠습니다. 현재 공지사항도 상세 모달을 열리는 기능만 추가했을 뿐입니다.
